### PR TITLE
Fix crash when get sessions

### DIFF
--- a/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/entity/mapper/SessionDataMapperExt.kt
+++ b/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/entity/mapper/SessionDataMapperExt.kt
@@ -40,21 +40,27 @@ fun SessionResponse.toSessionEntityImpl(
     categories: List<CategoryResponse>,
     rooms: List<RoomResponse>
 ): SessionEntityImpl {
-    val sessionFormat = categories.category(0, categoryItems[0])
-    val language = categories.category(1, categoryItems[1])
-    val topic = categories.category(2, categoryItems[2])
+    val sessionFormat = categoryItems.getOrNull(0)?.let {
+        categories.category(0, it)
+    }
+    val language = categoryItems.getOrNull(1)?.let {
+        categories.category(1, it)
+    }
+    val topic = categoryItems.getOrNull(2)?.let {
+        categories.category(2, it)
+    }
     return SessionEntityImpl(
         id = id,
         title = title,
         desc = description,
         stime = dateFormat.parse(startsAt).utc.unixMillisLong,
         etime = dateFormat.parse(endsAt).utc.unixMillisLong,
-        sessionFormat = sessionFormat.name!!,
-        language = language.name!!,
+        sessionFormat = sessionFormat?.name ?: "",
+        language = language?.name ?: "",
         message = message?.let {
             MessageEntityImpl(it.ja!!, it.en!!)
         },
-        topic = TopicEntityImpl(topic.id!!, topic.name!!),
+        topic = TopicEntityImpl(topic?.id ?: 0, topic?.name ?: ""),
         room = RoomEntityImpl(roomId, rooms.roomName(roomId))
     )
 }

--- a/data/repository-impl/src/main/java/io/github/droidkaigi/confsched2019/data/repository/mapper/SessionMappers.kt
+++ b/data/repository-impl/src/main/java/io/github/droidkaigi/confsched2019/data/repository/mapper/SessionMappers.kt
@@ -15,12 +15,12 @@ fun SessionWithSpeakers.toSession(
     firstDay: DateTime
 ): Session.SpeechSession {
     val sessionEntity = session
-    require(speakerIdList.isNotEmpty())
+    //require(speakerIdList.isNotEmpty())
     val speakers = speakerIdList.map { speakerId ->
         val speakerEntity = speakerEntities.first { it.id == speakerId }
         speakerEntity.toSpeaker()
     }
-    require(speakers.isNotEmpty())
+    //require(speakers.isNotEmpty())
     return Session.SpeechSession(
         id = sessionEntity.id,
         // dayNumber is starts with 1.

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpecialSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpecialSessionItem.kt
@@ -8,7 +8,7 @@ import io.github.droidkaigi.confsched2019.session.databinding.ItemSpecialSession
 class SpecialSessionItem(
     override val session: Session.SpecialSession
 ) : BindableItem<ItemSpecialSessionBinding>(
-    session.id.toLong()
+    session.hashCode().toLong()
 ), SessionItem {
     val specialSession get() = session
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
@@ -29,7 +29,7 @@ class SpeechSessionItem @AssistedInject constructor(
     sessionContentsActionCreator: SessionContentsActionCreator,
     val systemStore: SystemStore
 ) : BindableItem<ItemSessionBinding>(
-    session.id.toLong()
+    session.hashCode().toLong()
 ), SessionItem {
     val speechSession get() = session
 


### PR DESCRIPTION
## Overview (Required)
- Hotfix
- Fix crash when get sessions
  - Because the id of service session can not convert to long