### PR TITLE
Show survey(enquete) text when end session

### DIFF
--- a/feature/session/src/main/res/drawable/ic_rate_review_border_orange_18dp.xml
+++ b/feature/session/src/main/res/drawable/ic_rate_review_border_orange_18dp.xml
@@ -1,0 +1,4 @@
+<vector android:height="18dp" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="18dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/colorSecondary" android:pathData="M20,2L4,2c-1.1,0 -1.99,0.9 -1.99,2L2,22l4,-4h14c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM20,16L5.17,16l-0.59,0.59 -0.58,0.58L4,4h16v12zM10.5,14L18,14v-2h-5.5zM14.36,8.13c0.2,-0.2 0.2,-0.51 0,-0.71l-1.77,-1.77c-0.2,-0.2 -0.51,-0.2 -0.71,0L6,11.53L6,14h2.47l5.89,-5.87z"/>
+</vector>

--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -200,6 +200,7 @@
                     android:contentDescription="@null"
                     android:layerType="software"
                     android:src="@drawable/shape_dashed_line"
+                    android:visibility="@{session.isFinished ? View.VISIBLE : View.GONE}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/session_tags"
@@ -207,27 +208,40 @@
 
 
                 <TextView
-                    android:id="@+id/session_survery_title"
+                    android:id="@+id/session_survey_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="16dp"
+                    android:layout_marginTop="26dp"
                     android:text="@string/session_detail_survey"
                     android:textAppearance="@style/TextAppearance.App.Subtitle1"
+                    android:visibility="@{session.isFinished ? View.VISIBLE : View.GONE}"
                     app:layout_constraintStart_toStartOf="@id/session_title"
                     app:layout_constraintTop_toBottomOf="@id/divider3"
+                    />
+
+                <TextView
+                    android:id="@+id/session_go_to_survey"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/session_detail_go_to_survey"
+                    android:textAppearance="@style/TextAppearance.App.Subtitle1"
+                    android:textColor="@color/colorSecondary"
+                    android:visibility="@{session.isFinished ? View.VISIBLE : View.GONE}"
+                    app:layout_constraintBaseline_toBaselineOf="@id/session_survey_title"
+                    app:layout_constraintEnd_toEndOf="@id/session_title"
                     />
 
                 <ImageView
                     android:id="@+id/divider4"
                     android:layout_width="0dp"
                     android:layout_height="4dp"
-                    android:layout_marginTop="28dp"
+                    android:layout_marginTop="26dp"
                     android:contentDescription="@null"
                     android:layerType="software"
                     android:src="@drawable/shape_dashed_line"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/session_survery_title"
+                    app:layout_constraintTop_toBottomOf="@id/session_survey_title"
                     />
 
                 <TextView

--- a/feature/session/src/main/res/layout/item_session.xml
+++ b/feature/session/src/main/res/layout/item_session.xml
@@ -85,7 +85,6 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="16dp"
             android:layout_marginTop="12dp"
-            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="@id/title"
             app:layout_constraintTop_toBottomOf="@id/time_and_room"
             >
@@ -128,12 +127,33 @@
             android:ellipsize="end"
             android:includeFontPadding="false"
             android:maxLines="3"
-            android:paddingBottom="2dp"
             android:textAlignment="viewStart"
             android:visibility="@{session.message == null ? View.GONE : View.VISIBLE}"
-            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="@id/title"
-            app:layout_constraintTop_toBottomOf="@id/time_and_room"
+            app:layout_constraintTop_toBottomOf="@id/chip_group"
+            tools:visibility="visible"
+            tools:text="セッションフロアがHallからRoom1に変更になりました"
+            />
+
+        <TextView
+            android:id="@+id/survey"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:drawablePadding="6dp"
+            android:ellipsize="end"
+            android:includeFontPadding="false"
+            android:maxLines="1"
+            android:drawableStart="@drawable/ic_rate_review_border_orange_18dp"
+            android:text="@string/session_go_to_survey"
+            android:textAlignment="viewStart"
+            android:textAppearance="@style/TextAppearance.App.Caption"
+            android:textColor="@color/colorSecondary"
+            android:visibility="@{session.isFinished ? View.VISIBLE : View.GONE}"
+            app:layout_constraintEnd_toEndOf="@id/title"
+            app:layout_constraintStart_toStartOf="@id/title"
+            app:layout_constraintTop_toBottomOf="@id/message"
+            tools:visibility="visible"
             />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/feature/session/src/main/res/values-ja/strings.xml
+++ b/feature/session/src/main/res/values-ja/strings.xml
@@ -4,5 +4,7 @@
     <string name="session_filter_reset">リセット</string>
     <string name="session_filter_button">絞り込む</string>
     <string name="session_detail_survey">アンケート</string>
+    <string name="session_detail_go_to_survey">回答する</string>
     <string name="session_search_hint">検索する…</string>
+    <string name="session_go_to_survey">アンケートに回答する</string>
 </resources>

--- a/feature/session/src/main/res/values/strings.xml
+++ b/feature/session/src/main/res/values/strings.xml
@@ -12,9 +12,11 @@
     <string name="session_filter_topic" translatable="false">Topic</string>
     <string name="session_detail_tag" translatable="false">Tags</string>
     <string name="session_detail_survey">Survey</string>
+    <string name="session_detail_go_to_survey">Go to survey</string>
     <string name="session_detail_speaker" translatable="false">Speaker</string>
     <string name="session_speaker_sessions" translatable="false">Session</string>
     <string name="session_share" translatable="false">Share</string>
     <string name="session_place" translatable="false">Place</string>
     <string name="session_search_hint">Search…</string>
+    <string name="session_go_to_survey">Go to survey</string>
 </resources>


### PR DESCRIPTION
## Issue
- close #120 

## Overview (Required)
- Show survey(enquete) text when end session
- Just display the text

### Session Detail
- Hide survey title and divider when the session has not ended yet

## Screenshot

### Session List
![device-2019-01-04-150544](https://user-images.githubusercontent.com/5106629/50675647-b9048080-1032-11e9-926a-101dd159988b.png)

### Session Detail
![device-2019-01-04-150605](https://user-images.githubusercontent.com/5106629/50675657-c3bf1580-1032-11e9-92b1-b2197fd73688.png)
