### PR TITLE
Add support for display cutouts

### DIFF
--- a/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/MainActivity.kt
+++ b/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/MainActivity.kt
@@ -7,6 +7,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.FragmentActivity
@@ -115,6 +116,17 @@ class MainActivity : DaggerAppCompatActivity() {
                 PorterDuff.Mode.SRC_ATOP
             )
             binding.toolbar.setTitleTextColor(toolbarContentsColor)
+
+            // Support display cutouts
+            val navHeaderOffsetView =
+                binding.navView.getHeaderView(0).findViewById<View>(R.id.offset_view)
+            ViewCompat.setOnApplyWindowInsetsListener(navHeaderOffsetView) { view, windowInsets ->
+                view.layoutParams.apply {
+                    height = windowInsets.systemWindowInsetTop
+                }
+
+                windowInsets
+            }
         }
     }
 

--- a/frontend/android/src/main/res/layout/layout_navigation_header.xml
+++ b/frontend/android/src/main/res/layout/layout_navigation_header.xml
@@ -1,21 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="100dp"
+    android:layout_height="wrap_content"
+    android:gravity="center_horizontal"
     >
 
-    <ImageView
-        android:id="@+id/navigation_header"
-        android:layout_width="wrap_content"
-        android:layout_height="24dp"
-        android:adjustViewBounds="true"
-        android:src="@drawable/bg_logo_black"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:contentDescription="@string/session_description_header_image"
+    <View
+        android:id="@+id/offset_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
         />
-</androidx.constraintlayout.widget.ConstraintLayout>
+
+    <ImageView
+        android:id="@+id/logo"
+        android:layout_width="wrap_content"
+        android:layout_height="26dp"
+        android:layout_marginBottom="32dp"
+        android:layout_marginTop="20dp"
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/session_description_header_image"
+        android:src="@drawable/bg_logo_black"
+        />
+
+</LinearLayout>
+


### PR DESCRIPTION
## Overview (Required)
- Use the WindowInsetsCompat to make the space of header of the NavigationView appropriate

## Screenshot

### Before (Pixel 3 XL)
![img_0463](https://user-images.githubusercontent.com/5106629/50726359-3d4c2600-114f-11e9-9aa1-126c1bbdda32.JPG)

### After (Pixel 3 XL)
![img_0466](https://user-images.githubusercontent.com/5106629/50726366-5654d700-114f-11e9-8a1b-8b43e0448d41.JPG)

### Before (PH-1)
![img_0465](https://user-images.githubusercontent.com/5106629/50726333-168def80-114f-11e9-8273-1c727f0696fb.JPG)

### After (PH-1)
![img_0467](https://user-images.githubusercontent.com/5106629/50726396-cb281100-114f-11e9-88fe-97aaa2757356.JPG)

### Before (ZenFone3)
![device-2019-01-06-011228](https://user-images.githubusercontent.com/5106629/50726434-3a9e0080-1150-11e9-9a18-a47ee52cd5c2.png)

### After (ZenFone3)
![device-2019-01-06-011341](https://user-images.githubusercontent.com/5106629/50726442-543f4800-1150-11e9-836a-d757534bf676.png)
