### PR TITLE
Fixed API endpoint to be used for the production build

### DIFF
--- a/data/api-impl/build.gradle
+++ b/data/api-impl/build.gradle
@@ -11,6 +11,19 @@ android.libraryVariants.all {
     it.generateBuildConfig.enabled = true
 }
 
+android {
+    defaultConfig {
+        buildConfigField "String", "API_ENDPOINT", "\"https://droidkaigi2019-dev.appspot.com/api\""
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            buildConfigField "String", "API_ENDPOINT", "\"https://droidkaigi-api.appspot.com/2019/api\""
+        }
+    }
+}
+
 dependencies {
     api project(":data:api")
 

--- a/data/api-impl/src/main/java/io/github/droidkaigi/confsched2019/data/api/ApiModule.kt
+++ b/data/api-impl/src/main/java/io/github/droidkaigi/confsched2019/data/api/ApiModule.kt
@@ -8,6 +8,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.serializer.KotlinxSerializer
+import javax.inject.Named
 import kotlinx.serialization.json.JSON
 import okhttp3.logging.HttpLoggingInterceptor
 
@@ -31,6 +32,10 @@ internal abstract class ApiModule {
                     serializer = KotlinxSerializer(JSON.nonstrict)
                 }
             }
+        }
+
+        @JvmStatic @Provides @Named("apiEndpoint") fun apiEndpoint(): String {
+            return BuildConfig.API_ENDPOINT
         }
     }
 }

--- a/data/api-impl/src/main/java/io/github/droidkaigi/confsched2019/data/api/KtorDroidKaigiApi.kt
+++ b/data/api-impl/src/main/java/io/github/droidkaigi/confsched2019/data/api/KtorDroidKaigiApi.kt
@@ -8,19 +8,21 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.url
 import javax.inject.Inject
+import javax.inject.Named
 
 class KtorDroidKaigiApi @Inject constructor(
-    val httpClient: HttpClient
+    val httpClient: HttpClient,
+    @Named("apiEndpoint") val apiEndpoint: String
 ) : DroidKaigiApi {
     override suspend fun getSponsors(): SponsorResponse {
         return httpClient.get<SponsorResponseImpl> {
-            url("https://droidkaigi.jp/2019/sponsors.json")
+            url("$apiEndpoint/sponsors")
         }
     }
 
     override suspend fun getSessions(): Response {
         return httpClient.get<ResponseImpl> {
-            url("https://droidkaigi2019-dev.appspot.com/api/timetable")
+            url("$apiEndpoint/timetable")
         }
     }
 }


### PR DESCRIPTION
## Issue
- None

## Overview (Required)

- This PR will change the api endpoint based on the configuration of the build type and the product flavor

FYI,

the production api endpoint url is `https://droidkaigi-api.appspot.com/2019/api`
the dev api endpoint url is `https://droidkaigi2019-dev.appspot.com/api`

## Links
- None.
