### PR TITLE
Fixed the date of the DroidKaigi 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DroidKaigi 2019 official Android app
 
-[DroidKaigi 2019](https://droidkaigi.jp/2019/en/) is a conference tailored for developers on 8th and 9th February 2019.
+[DroidKaigi 2019](https://droidkaigi.jp/2019/en/) is a conference tailored for developers on 7th and 8th February 2019.
 
 [<img src="https://dply.me/b9riom/button/large" alt="Try it on your device via DeployGate">](https://dply.me/b9riom#install)
 


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- The correct date is 7 and 8 Feb. :)

## Links
- https://droidkaigi.jp/2019/