### PR TITLE
Fixed a crash when opening the sponsor screen

### DIFF
--- a/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/di/RepositoryComponentModule.kt
+++ b/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/di/RepositoryComponentModule.kt
@@ -33,12 +33,14 @@ object RepositoryComponentModule {
 
     @JvmStatic @Provides @Singleton fun provideSponsorRepository(
         droidKaigiApi: DroidKaigiApi,
+        googleFormApi: GoogleFormApi,
         database: SessionDatabase,
         sponsorDatabase: SponsorDatabase,
         fireStore: FireStore
     ): SponsorRepository {
         return RepositoryComponent.builder()
             .droidKaigiApi(droidKaigiApi)
+            .googleFormApi(googleFormApi)
             .database(database)
             .sponsorDatabase(sponsorDatabase)
             .fireStore(fireStore)


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- GoogleFormApi is required to build the dagger component now

## Links
- none
