### PR TITLE
set autolink in speaker bio

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SpeakerFragment.kt
@@ -2,7 +2,6 @@ package io.github.droidkaigi.confsched2019.session.ui
 
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
-import android.text.util.Linkify
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -55,7 +54,6 @@ class SpeakerFragment : DaggerFragment() {
         ) { speaker ->
             binding.speaker = speaker
         }
-        binding.speakerDescription.autoLinkMask = Linkify.WEB_URLS
         binding.speakerDescription.movementMethod = LinkMovementMethod.getInstance()
 
         sessionContentsStore.speechSessionBySpeakerName(speakerId)

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SpeakerFragment.kt
@@ -1,6 +1,8 @@
 package io.github.droidkaigi.confsched2019.session.ui
 
 import android.os.Bundle
+import android.text.method.LinkMovementMethod
+import android.text.util.Linkify
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -53,6 +55,8 @@ class SpeakerFragment : DaggerFragment() {
         ) { speaker ->
             binding.speaker = speaker
         }
+        binding.speakerDescription.autoLinkMask = Linkify.WEB_URLS
+        binding.speakerDescription.movementMethod = LinkMovementMethod.getInstance()
 
         sessionContentsStore.speechSessionBySpeakerName(speakerId)
             .changed(viewLifecycleOwner) { session ->

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/AutoLinkBinding.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/AutoLinkBinding.kt
@@ -1,0 +1,14 @@
+package io.github.droidkaigi.confsched2019.session.ui.bindingadapter
+
+import android.text.util.Linkify
+import androidx.databinding.BindingAdapter
+import androidx.emoji.widget.EmojiTextView
+
+@BindingAdapter(value = ["app:textLinkify"])
+fun EmojiTextView.setTextLinkify(
+    isLinkify: Boolean
+) {
+    if (isLinkify) {
+        Linkify.addLinks(this, Linkify.WEB_URLS)
+    }
+}

--- a/feature/session/src/main/res/layout/fragment_speaker.xml
+++ b/feature/session/src/main/res/layout/fragment_speaker.xml
@@ -117,6 +117,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="@id/speaker_name"
                     app:layout_constraintTop_toBottomOf="@id/divider1"
+                    app:textLinkify="@{true}"
                     tools:text="Material is the metaphor A material metaphor is the unifying theory of a rationalized space and a system of motion. The material is grounded in tactile reality, inspired by the study of paper and ink, yet technologically advanced and open to imagination and magic."
                     />
 

--- a/feature/session/src/main/res/layout/fragment_speaker.xml
+++ b/feature/session/src/main/res/layout/fragment_speaker.xml
@@ -105,7 +105,6 @@
 
                 <androidx.emoji.widget.EmojiTextView
                     android:id="@+id/speaker_description"
-                    android:autoLink="web"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="16dp"

--- a/feature/session/src/main/res/layout/fragment_speaker.xml
+++ b/feature/session/src/main/res/layout/fragment_speaker.xml
@@ -105,6 +105,7 @@
 
                 <androidx.emoji.widget.EmojiTextView
                     android:id="@+id/speaker_description"
+                    android:autoLink="web"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="16dp"


### PR DESCRIPTION
## Issue
- close #182 

## Overview (Required)
- set autolink="web" at the section of speaker description in speaker fragment.

## Links
- https://developer.android.com/reference/android/widget/TextView#attr_android:autoLink

## Screenshot
Before | After
:--: | :--:
![beforeweblink](https://user-images.githubusercontent.com/7840108/50778282-e6765600-12e0-11e9-9d6e-1377bb70b379.png) | ![weblink](https://user-images.githubusercontent.com/7840108/50778293-f130eb00-12e0-11e9-9d69-403726cab460.png)
![beforeweblink](https://user-images.githubusercontent.com/7840108/50778282-e6765600-12e0-11e9-9d6e-1377bb70b379.png)  | ![weblink](https://user-images.githubusercontent.com/7840108/50778404-381ee080-12e1-11e9-99ca-5292084a8b23.gif)

<img src="" width="300" /> | <img src="" width="300" />
