### PR TITLE
To selectable the session description

### DIFF
--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -125,6 +125,7 @@
                     android:paddingBottom="2dp"
                     android:text="@{session.desc}"
                     android:textAlignment="viewStart"
+                    android:textIsSelectable="true"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="@id/session_title"
                     app:layout_constraintTop_toBottomOf="@id/divider1"


### PR DESCRIPTION
## Issue
- close #175

## Overview (Required)
- By setting to `android:textIsSelectable="true"`, text of session description can be selected.

## Links
- https://developer.android.com/reference/android/widget/TextView#attr_android:textIsSelectable

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/2193123/50779980-28090000-12e5-11e9-9ca1-cf3000d132e9.png" width="300" /> | <img src="https://user-images.githubusercontent.com/2193123/50780023-3eaf5700-12e5-11e9-9526-b38035053c53.png" width="300" />
