### PR TITLE
Fixed the bugs to backgroundTint of FloatingActionButton on Android 5.0

### DIFF
--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -302,8 +302,8 @@
             android:id="@+id/session_favorite"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:backgroundTint="@color/colorPrimary"
             android:src="@{session.isFavorited? @drawable/ic_bookmark_black_24dp : @drawable/ic_bookmark_border_black_24dp}"
+            app:backgroundTint="@color/colorPrimary"
             app:layout_anchor="@id/bottom_app_bar"
             app:tint="@color/white"
             />


### PR DESCRIPTION
## Issue
- close #190

## Overview (Required)
- Changed `android:backgroundTint` to `app:backgroundTint`

## Links
- https://developer.android.com/reference/android/R.attr#backgroundTint
- https://issuetracker.google.com/issues/37126253

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/31527039/50780780-2c361d00-12e7-11e9-8ef1-3ea936ac039d.png" width="300" /> | <img src="https://user-images.githubusercontent.com/31527039/50780806-3ce69300-12e7-11e9-81b2-b676ae8c3681.png" width="300" />
