### PR TITLE
Fix typo - privacy policy

### DIFF
--- a/feature/about/src/main/res/values-ja/strings.xml
+++ b/feature/about/src/main/res/values-ja/strings.xml
@@ -6,7 +6,7 @@
     <string name="about_check_map">Mapを開く</string>
     <string name="about_staff_list">スタッフリスト</string>
     <string name="about_check">見てみる</string>
-    <string name="about_privacy_policy">プライバシーポシリー</string>
+    <string name="about_privacy_policy">プライバシーポリシー</string>
     <string name="about_license">ライセンス</string>
     <string name="about_app_version">アプリバージョン</string>
 </resources>

--- a/feature/about/src/main/res/values/strings.xml
+++ b/feature/about/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="about_check_map">Mapを開く</string>
     <string name="about_staff_list">スタッフリスト</string>
     <string name="about_check">見てみる</string>
-    <string name="about_privacy_policy">プライバシーポシリー</string>
+    <string name="about_privacy_policy">プライバシーポリシー</string>
     <string name="about_license">ライセンス</string>
     <string name="about_app_version">アプリバージョン</string>
     <string name="about_version_name" translatable="false">1.0.0</string>


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- Fix typo "プライバシーポシリー" → "プライバシーポリシー" ( It's so cute, but I fixed it.😜)

## Links
- None

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
