### PR TITLE
Fix session time texts on session list not to be overlapped

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
@@ -23,8 +23,11 @@ class SessionsItemDecoration(
     private val textLeftSpace = resources.getDimensionPixelSize(
         R.dimen.session_bottom_sheet_left_time_text_left
     )
-    private val textMinTop = resources.getDimensionPixelSize(
-        R.dimen.session_bottom_sheet_left_time_text_top_min
+    private val textPaddingTop = resources.getDimensionPixelSize(
+        R.dimen.session_bottom_sheet_left_time_text_padding_top
+    )
+    private val textPaddingBottom = resources.getDimensionPixelSize(
+        R.dimen.session_bottom_sheet_left_time_text_padding_bottom
     )
 
     val paint = Paint().apply {
@@ -45,37 +48,34 @@ class SessionsItemDecoration(
             val view = parent.getChildAt(i)
             val position = parent.getChildAdapterPosition(view)
             if (position == -1 || position >= groupAdapter.itemCount) return
-            val item = groupAdapter.getItem(position)
-            val previousItem = if (position - 1 < 0) {
-                null
-            } else {
-                groupAdapter.getItem(position - 1)
+
+            val time = getSessionTime(position) ?: continue
+
+            if (lastTime == time) continue
+            lastTime = time
+
+            val nextTime = getSessionTime(position + 1)
+
+            var textY = view.top.coerceAtLeast(0) + textPaddingTop + textSize
+            if (time != nextTime) {
+                textY = textY.coerceAtMost(view.bottom - textPaddingBottom)
             }
-            if (item is SessionItem) {
-                val time = item.session.startTime.toString("HH:mm")
-                val previousTime = if (previousItem is SessionItem) {
-                    previousItem.session.startTime.toString("HH:mm")
-                } else {
-                    null
-                }
 
-                if (lastTime == time) continue
-
-                lastTime = time
-
-                val yPosition = if (view.top < 0 || time == previousTime) {
-                    textSize
-                } else {
-                    view.top + textSize
-                }
-
-                c.drawText(
-                    time,
-                    textLeftSpace.toFloat(),
-                    yPosition.toFloat(),
-                    paint
-                )
-            }
+            c.drawText(
+                time,
+                textLeftSpace.toFloat(),
+                textY.toFloat(),
+                paint
+            )
         }
+    }
+
+    private fun getSessionTime(position: Int): String? {
+        if (position < 0 || position >= groupAdapter.itemCount) {
+            return null
+        }
+
+        val item = groupAdapter.getItem(position) as? SessionItem
+        return item?.session?.startTime?.toString("HH:mm")
     }
 }

--- a/feature/session/src/main/res/values/dimens.xml
+++ b/feature/session/src/main/res/values/dimens.xml
@@ -3,7 +3,8 @@
     <dimen name="session_bottom_sheet_left_time_space">76dp</dimen>
     <dimen name="session_bottom_sheet_left_time_text_size">20dp</dimen>
     <dimen name="session_bottom_sheet_left_time_text_left">16dp</dimen>
-    <dimen name="session_bottom_sheet_left_time_text_top_min">22dp</dimen>
+    <dimen name="session_bottom_sheet_left_time_text_padding_top">0dp</dimen>
+    <dimen name="session_bottom_sheet_left_time_text_padding_bottom">8dp</dimen>
     <dimen name="session_bottom_sheet_filter_icon_padding">8dp</dimen>
     <dimen name="session_bottom_sheet_filter_text_padding">0dp</dimen>
     <dimen name="session_item_top_padding">4dp</dimen>


### PR DESCRIPTION
## Issue
- close #51

## Overview (Required)
- Fixed item decoration drawing session time texts on session list so that the texts are not overlapped

## Links
N/A

## Screenshot
Before | After
:--: | :--:
![svid_20190108_001357_1](https://user-images.githubusercontent.com/12084705/50786974-1589c900-12db-11e9-8923-49f57130fafc.gif) | ![svid_20190108_001100_1](https://user-images.githubusercontent.com/12084705/50786973-1589c900-12db-11e9-9fbb-3aa85e540d23.gif)