### PR TITLE
Fix hamburger icon and title misaligned

### DIFF
--- a/frontend/android/src/main/res/layout/activity_main.xml
+++ b/frontend/android/src/main/res/layout/activity_main.xml
@@ -33,7 +33,7 @@
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="0dp"
-                android:layout_height="64dp"
+                android:layout_height="wrap_content"
                 android:background="@{isWhiteTheme ? Converters.convertColorToDrawable(@color/white) : Converters.convertColorToDrawable(@color/colorPrimary)}"
                 android:elevation="0dp"
                 app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2019/issues/196

## Overview (Required)
- toolbar changes the height from 64dp to wrap_content

## Links
- https://developer.android.com/training/multiscreen/screensizes?hl=ja#TaskUseWrapMatchPar

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/11706821/50801663-1a756980-1329-11e9-9073-53793ba08bac.png" width="300" /> | <img src="https://user-images.githubusercontent.com/11706821/50801669-206b4a80-1329-11e9-94ef-0743cf95b968.png" width="300" />
