### PR TITLE
Add English recources for About screen

### DIFF
--- a/feature/about/src/main/res/values/strings.xml
+++ b/feature/about/src/main/res/values/strings.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="about_what_is_droidkaigi">What is DroidKaigi</string>
-    <string name="about_description_droidkaigi">DroidKaigiはエンジニアが主役のAndroidカンファレンスです。 \nAndroid技術情報の共有とコミュニケーションを目的に、2019年2月7日(木)、8日(金)の2日間開催します。</string>
-    <string name="about_access_to_place">会場アクセス</string>
-    <string name="about_check_map">Mapを開く</string>
-    <string name="about_staff_list">スタッフリスト</string>
-    <string name="about_check">見てみる</string>
-    <string name="about_privacy_policy">プライバシーポリシー</string>
-    <string name="about_license">ライセンス</string>
-    <string name="about_app_version">アプリバージョン</string>
+    <string name="about_what_is_droidkaigi">About DroidKaigi</string>
+    <string name="about_description_droidkaigi">DroidKaigi is a conference tailored for Android developers. It\'s schedule to take place on the 7th and 8th of February 2019.</string>
+    <string name="about_access_to_place">Directions</string>
+    <string name="about_check_map">Open with Maps</string>
+    <string name="about_staff_list">Operation Team</string>
+    <string name="about_check">See Details</string>
+    <string name="about_privacy_policy">Privacy Policy</string>
+    <string name="about_license">Open Sources Licenses</string>
+    <string name="about_app_version">Version</string>
     <string name="about_version_name" translatable="false">1.0.0</string>
 </resources>

--- a/feature/about/src/main/res/values/strings.xml
+++ b/feature/about/src/main/res/values/strings.xml
@@ -4,10 +4,10 @@
     <string name="about_description_droidkaigi">DroidKaigi is a conference tailored for Android developers. It\'s scheduled to take place on the 7th and 8th of February 2019.</string>
     <string name="about_access_to_place">Directions</string>
     <string name="about_check_map">Open with Maps</string>
-    <string name="about_staff_list">Operation Team</string>
+    <string name="about_staff_list">Committee Members</string>
     <string name="about_check">See Details</string>
     <string name="about_privacy_policy">Privacy Policy</string>
-    <string name="about_license">Open Sources Licenses</string>
+    <string name="about_license">Open Source Licenses</string>
     <string name="about_app_version">Version</string>
     <string name="about_version_name" translatable="false">1.0.0</string>
 </resources>

--- a/feature/about/src/main/res/values/strings.xml
+++ b/feature/about/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="about_what_is_droidkaigi">About DroidKaigi</string>
-    <string name="about_description_droidkaigi">DroidKaigi is a conference tailored for Android developers. It\'s schedule to take place on the 7th and 8th of February 2019.</string>
+    <string name="about_what_is_droidkaigi">What is DroidKaigi?</string>
+    <string name="about_description_droidkaigi">DroidKaigi is a conference tailored for Android developers. It\'s scheduled to take place on the 7th and 8th of February 2019.</string>
     <string name="about_access_to_place">Directions</string>
     <string name="about_check_map">Open with Maps</string>
     <string name="about_staff_list">Operation Team</string>


### PR DESCRIPTION
## Issue
- close #142

## Overview (Required)
- Add strings.xml resources in English for About screen

## Links
- https://github.com/DroidKaigi/conference-app-2019/blob/master/feature/about/src/main/res/values/strings.xml

## Screenshot
<img src="https://i.gyazo.com/70dcdf0e7d9f40677858965808e59382.png" width="300" />