### PR TITLE
Restore searched text

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SearchFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SearchFragment.kt
@@ -68,8 +68,8 @@ class SearchFragment : DaggerFragment() {
 
         sessionContentsStore.sessionContents.changed(viewLifecycleOwner) { contents ->
             searchActionCreator.search(
-                searchView?.query?.toString(),
-                sessionContentsStore.sessionContents.requireValue()
+                searchStore.searchResult.value?.query,
+                contents
             )
         }
         // TODO apply design
@@ -105,6 +105,7 @@ class SearchFragment : DaggerFragment() {
         inflater.inflate(R.menu.menu_toolbar_search, menu)
         searchView = menu.findItem(R.id.menu_search).actionView as SearchView
         searchView?.let { searchView ->
+            searchView.setQuery(searchStore.searchResult.value?.query, false)
             searchView.isIconified = false
             searchView.clearFocus()
             searchView.queryHint = getString(R.string.session_search_hint)

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SearchActionCreator.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SearchActionCreator.kt
@@ -24,7 +24,8 @@ class SearchActionCreator @Inject constructor(
                 Action.SearchResultLoaded(
                     SearchResult(
                         listOf(),
-                        sessionContents.speakers
+                        sessionContents.speakers,
+                        query
                     )
                 )
             )

--- a/model/src/commonMain/kotlin/SearchResult.kt
+++ b/model/src/commonMain/kotlin/SearchResult.kt
@@ -2,9 +2,10 @@ package io.github.droidkaigi.confsched2019.model
 
 class SearchResult(
     val sessions: List<Session>,
-    val speakers: List<Speaker>
+    val speakers: List<Speaker>,
+    val query: String?
 ) {
     companion object {
-        val EMPTY = SearchResult(listOf(), listOf())
+        val EMPTY = SearchResult(listOf(), listOf(), null)
     }
 }

--- a/model/src/commonMain/kotlin/SessionContents.kt
+++ b/model/src/commonMain/kotlin/SessionContents.kt
@@ -35,7 +35,8 @@ data class SessionContents(
             },
             speakers.filter {
                 find(query, it.name, it.tagLine, it.bio, it.githubUrl, it.twitterUrl)
-            }
+            },
+            query
         )
     }
 


### PR DESCRIPTION
## Issue
- close #176

## Overview (Required)
- Restore searched text when return from detail screen. Add query string in searchStore and restored it when onCreateOptionsMenu.
- I'd like to confirm specification. I move query string to global store, so this case `session -> search -> session detail -> back -> back to session -> search again`  query string is restored, is it ok ?

## Links
- none

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/5106629/50738023-d6904080-1212-11e9-85f5-d9e8869aa21f.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/3154259/50813323-588a8180-1359-11e9-97bf-58e0a3e9ad7d.gif" width="300" />
