### PR TITLE
Delete thin line in the tab

### DIFF
--- a/feature/session/src/main/res/layout/layout_title_chip.xml
+++ b/feature/session/src/main/res/layout/layout_title_chip.xml
@@ -19,6 +19,7 @@
         android:textColor="@color/white"
         app:chipBackgroundColor="@color/colorPrimary"
         app:chipStrokeColor="@color/selector_tab_title"
+        app:chipSurfaceColor="@android:color/transparent"
         app:chipStrokeWidth="1dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## Issue
- close #172 

## Overview (Required)
- set chipSurfaceColor ="[at]android:color/transparent"

Default chipSurfaceColor is `#FFFFFF`. (if light theme)
[ChipDrawable](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/chip/ChipDrawable.java) has surface layer and background. Probably the cause is this.

## Links
https://github.com/material-components/material-components-android/blob/6c70169e8d4ae77429a9c57785e443b2a18b4aa3/lib/java/com/google/android/material/chip/ChipDrawable.java#L593-L594

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/7961496/50829053-92be4800-1386-11e9-8dd5-b74f0d60a4e9.png" width="300" /> | <img src="https://user-images.githubusercontent.com/7961496/50829141-d4e78980-1386-11e9-833a-e25f28b4f25d.png" width="300" />