### PR TITLE
Simplify handler code of CoroutinePlugin.

### DIFF
--- a/ext/android-extension/src/main/java/io/github/droidkaigi/confsched2019/ext/android/CoroutinePlugin.kt
+++ b/ext/android-extension/src/main/java/io/github/droidkaigi/confsched2019/ext/android/CoroutinePlugin.kt
@@ -8,25 +8,20 @@ object CoroutinePlugin {
 
     private val defaultIoDispatcher: CoroutineContext = Dispatchers.IO
     val ioDispatcher: CoroutineContext
-        get() = ioDispatcherHandler?.let { handler ->
-            handler(defaultIoDispatcher)
-        } ?: defaultIoDispatcher
+        get() = ioDispatcherHandler?.invoke(defaultIoDispatcher) ?: defaultIoDispatcher
     @set:VisibleForTesting
     var ioDispatcherHandler: ((CoroutineContext) -> CoroutineContext)? = null
 
     private val defaultComputationDispatcher: CoroutineContext = Dispatchers.Default
     val defaultDispatcher: CoroutineContext
-        get() = computationDispatcherHandler?.let { handler ->
-            handler(defaultComputationDispatcher)
-        } ?: defaultComputationDispatcher
+        get() = computationDispatcherHandler?.invoke(defaultComputationDispatcher)
+            ?: defaultComputationDispatcher
     @set:VisibleForTesting
     var computationDispatcherHandler: ((CoroutineContext) -> CoroutineContext)? = null
 
     private val defaultMainDispatcher: CoroutineContext = Dispatchers.Main
     val mainDispatcher: CoroutineContext
-        get() = mainDispatcherHandler?.let { handler ->
-            handler(defaultMainDispatcher)
-        } ?: defaultMainDispatcher
+        get() = mainDispatcherHandler?.invoke(defaultMainDispatcher) ?: defaultMainDispatcher
     @set:VisibleForTesting
     var mainDispatcherHandler: ((CoroutineContext) -> CoroutineContext)? = null
 


### PR DESCRIPTION
## Issue

related to: Rethink how to inject Coroutine Dispacthers #236

## Overview (Required)

Simplify handler code of CoroutinePlugin.
use invoke() instead of let().

## Links

none

## Screenshot

none