### PR TITLE
Add some unique character string treated as typo to the dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /local.properties
 /.idea/*
 !/.idea/codeStyles/
+!/.idea/dictionaries/
 .DS_Store
 lint-results.*
 build/

--- a/.idea/dictionaries/dic.xml
+++ b/.idea/dictionaries/dic.xml
@@ -1,0 +1,19 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="dic">
+    <words>
+      <w>circleci</w>
+      <w>confsched</w>
+      <w>databinding</w>
+      <w>deploygate</w>
+      <w>droidkaigi</w>
+      <w>emoji</w>
+      <w>firebase</w>
+      <w>firestore</w>
+      <w>jetifier</w>
+      <w>kaigi</w>
+      <w>ktor</w>
+      <w>recyclerview</w>
+      <w>stetho</w>
+    </words>
+  </dictionary>
+</component>


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Please try reopen Android Studio project. The warnings of some unique character string treated as typo has disappeared.

## Links
- https://note.mu/nikkei_staff/n/n5685d32e6540
>11.3 Typo Lint を辞書運⽤で制御する

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/11440952/50834361-30217800-1397-11e9-99ab-f67086a77ada.png" width="300" /> | <img src="https://user-images.githubusercontent.com/11440952/50834360-30217800-1397-11e9-895d-c16fedd098a4.png" width="300" />






