### PR TITLE
Replace ImageView and TextView in LinearLayout with TextView with com…

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/TextViewBinding.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/TextViewBinding.kt
@@ -1,0 +1,70 @@
+package io.github.droidkaigi.confsched2019.session.ui.bindingadapter
+
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.widget.TextView
+import androidx.core.graphics.drawable.DrawableCompat
+import com.squareup.picasso.Picasso
+import com.squareup.picasso.Target
+import jp.wasabeef.picasso.transformations.CropCircleTransformation
+
+
+fun loadImage(
+    textView: TextView,
+    imageUrl: String?,
+    circleCrop: Boolean?,
+    rawPlaceHolder: Drawable?,
+    placeHolderTint: Int?,
+    widthDp: Int = 16,
+    heightDp: Int = 16
+) {
+    fun setDrawable(drawable: Drawable) {
+        val res = textView.context.resources
+        val widthPx = (widthDp * res.displayMetrics.density).toInt()
+        val heightPx = (heightDp * res.displayMetrics.density).toInt()
+        drawable.setBounds(0, 0, widthPx, heightPx)
+        textView.setCompoundDrawables(drawable, null, null, null)
+    }
+
+    val placeHolder = run {
+        DrawableCompat.wrap(
+            rawPlaceHolder ?: return@run null
+        )?.apply {
+            setTint(placeHolderTint ?: return@run this)
+        }
+    }
+    imageUrl ?: run {
+        placeHolder?.let {
+            setDrawable(it)
+        }
+    }
+
+    Picasso
+        .get()
+        .load(imageUrl)
+        .apply {
+            if (circleCrop == true) {
+                transform(CropCircleTransformation())
+            }
+            if (placeHolder != null) {
+                placeholder(placeHolder)
+            }
+        }
+        .into(object : Target {
+            override fun onPrepareLoad(placeHolderDrawable: Drawable?) {
+                placeHolderDrawable?.let {
+                    setDrawable(it)
+                }
+            }
+
+            override fun onBitmapFailed(e: Exception?, errorDrawable: Drawable?) {
+            }
+
+            override fun onBitmapLoaded(bitmap: Bitmap?, from: Picasso.LoadedFrom?) {
+                val res = textView.context.resources
+                val drawable = BitmapDrawable(res, bitmap)
+                setDrawable(drawable)
+            }
+        })
+}

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
@@ -3,7 +3,6 @@ package io.github.droidkaigi.confsched2019.session.ui.item
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
@@ -102,11 +101,8 @@ class SpeechSessionItem @AssistedInject constructor(
                 val speakerView = layoutInflater.get(root.context).inflate(
                     R.layout.layout_speaker, speakers, false
                 ) as ViewGroup
-                val imageView: ImageView = speakerView.findViewById(
-                    R.id.speaker_image
-                )
                 val textView: TextView = speakerView.findViewById(R.id.speaker)
-                bindSpeakerData(speaker, textView, imageView)
+                bindSpeakerData(speaker, textView)
 
                 speakers.addView(speakerView)
                 return@forEach
@@ -114,19 +110,17 @@ class SpeechSessionItem @AssistedInject constructor(
             if (existSpeakerView != null && speaker != null) {
                 val textView: TextView = existSpeakerView.findViewById(R.id.speaker)
                 textView.text = speaker.name
-                val imageView = existSpeakerView.findViewById<ImageView>(R.id.speaker_image)
-                bindSpeakerData(speaker, textView, imageView)
+                bindSpeakerData(speaker, textView)
             }
         }
     }
 
     private fun bindSpeakerData(
         speaker: Speaker,
-        textView: TextView,
-        imageView: ImageView
+        textView: TextView
     ) {
         textView.text = speaker.name
-        val context = imageView.context
+        val context = textView.context
         val placeHolder = VectorDrawableCompat.create(
             context.resources,
             R.drawable.ic_person_outline_black_24dp,
@@ -137,7 +131,7 @@ class SpeechSessionItem @AssistedInject constructor(
             R.color.gray2
         )
         loadImage(
-            imageView = imageView,
+            textView = textView,
             imageUrl = speaker.imageUrl,
             circleCrop = true,
             rawPlaceHolder = placeHolder,

--- a/feature/session/src/main/res/layout/layout_speaker.xml
+++ b/feature/session/src/main/res/layout/layout_speaker.xml
@@ -6,18 +6,11 @@
     android:layout_height="wrap_content"
     >
 
-    <ImageView
-        android:id="@+id/speaker_image"
-        android:layout_width="16dp"
-        android:layout_height="16dp"
-        android:contentDescription="@string/speaker_label"
-        />
-
     <TextView
         android:id="@+id/speaker"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="4dp"
+        android:drawablePadding="4dp"
         android:textAppearance="?textAppearanceCaption"
         tools:text="taka"
         />


### PR DESCRIPTION
…pound drawable in layout_speaker

## Issue
- close #50

## Overview (Required)
- Lint warned ImageView and TextView in LinearLayout. It suggest to use TextView with compaund drawable
  - Set drawable by `TextView#setCompoundDrawables()`. It is out of scope of `ImageViewBinding`, I added `TextViewBinding` for this. 

## Links
- 

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1650277/50834985-d0c46780-1398-11e9-9c21-59d1f51b06cb.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/1650277/50835174-6102ac80-1399-11e9-9248-f511995238b3.gif" width="300" />

