### PR TITLE
set auto link in speaker fragment

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SpeakerFragment.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched2019.session.ui
 
 import android.os.Bundle
+import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -53,7 +54,7 @@ class SpeakerFragment : DaggerFragment() {
         ) { speaker ->
             binding.speaker = speaker
         }
-
+        binding.speakerDescription.movementMethod = LinkMovementMethod.getInstance()
         sessionContentsStore.speechSessionBySpeakerName(speakerId)
             .changed(viewLifecycleOwner) { session ->
                 binding.session = session

--- a/feature/session/src/main/res/layout/fragment_speaker.xml
+++ b/feature/session/src/main/res/layout/fragment_speaker.xml
@@ -104,6 +104,7 @@
                     />
 
                 <androidx.emoji.widget.EmojiTextView
+                    android:autoLink="web"
                     android:id="@+id/speaker_description"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
## Issue
- close #182 

## Overview (Required)
- set autolink="web" at the section of speaker description in speaker fragment.
- set movementMethod expressly.

## Links
- https://developer.android.com/reference/android/widget/TextView#attr_android:autoLink
- https://github.com/DroidKaigi/conference-app-2019/pull/218#discussion_r246022165

## Screenshot
Before | After
:--: | :--:
![beforeweblink](https://user-images.githubusercontent.com/7840108/50778282-e6765600-12e0-11e9-9d6e-1377bb70b379.png) | ![autolink](https://user-images.githubusercontent.com/7840108/50839367-809ed280-13a3-11e9-9b51-35bc3427840a.png)
![beforeweblink](https://user-images.githubusercontent.com/7840108/50778282-e6765600-12e0-11e9-9d6e-1377bb70b379.png)  | ![autolink](https://user-images.githubusercontent.com/7840108/50839312-606f1380-13a3-11e9-8a4f-3dae89a71dd3.gif)


<img src="" width="300" /> | <img src="" width="300" />
