### PR TITLE
show simultaneous interpretation tag on session view

### DIFF
--- a/data/api-impl/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/response/SessionResponseImpl.kt
+++ b/data/api-impl/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/response/SessionResponseImpl.kt
@@ -18,5 +18,6 @@ data class SessionResponseImpl(
     override val questionAnswers: List<QuestionAnswerResponseImpl>,
     override val sessionType: String?,
     @Optional override val message: SessionMessageResponseImpl? = null,
-    override val isPlenumSession: Boolean
+    override val isPlenumSession: Boolean,
+    override val interpretationTarget: Boolean
 ) : SessionResponse

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/response/SessionResponse.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/response/SessionResponse.kt
@@ -15,4 +15,5 @@ interface SessionResponse {
     val message: SessionMessageResponse?
     val isPlenumSession: Boolean
     val sessionType: String?
+    val interpretationTarget: Boolean
 }

--- a/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/CacheDatabase.kt
+++ b/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/CacheDatabase.kt
@@ -22,7 +22,7 @@ import io.github.droidkaigi.confsched2019.data.db.entity.SponsorEntityImpl
         (SponsorEntityImpl::class),
         (SessionFeedbackImpl::class)
     ],
-    version = 7
+    version = 8
 )
 abstract class CacheDatabase : RoomDatabase() {
     abstract fun sessionDao(): SessionDao

--- a/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/entity/SessionEntityImpl.kt
+++ b/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/entity/SessionEntityImpl.kt
@@ -16,6 +16,7 @@ data class SessionEntityImpl(
     override var sessionFormat: String?,
     override val sessionType: String?,
     override val intendedAudience: String?,
+    override val isInterpretationTarget: Boolean,
     @Embedded override var language: LanguageEntityImpl?,
     @Embedded override val category: CategoryEntityImpl?,
     @Embedded override val room: RoomEntityImpl?,

--- a/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/entity/mapper/SessionDataMapperExt.kt
+++ b/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/entity/mapper/SessionDataMapperExt.kt
@@ -77,6 +77,7 @@ fun SessionResponse.toSessionEntityImpl(
                 requireNotNull(category.translatedName?.en)
             ),
             intendedAudience = intendedAudience,
+            isInterpretationTarget = interpretationTarget,
             room = RoomEntityImpl(roomId, rooms.roomName(roomId)),
             sessionType = sessionType
         )
@@ -94,6 +95,7 @@ fun SessionResponse.toSessionEntityImpl(
             category = null,
             room = RoomEntityImpl(roomId, rooms.roomName(roomId)),
             intendedAudience = null,
+            isInterpretationTarget = interpretationTarget,
             message = message?.let {
                 MessageEntityImpl(requireNotNull(it.ja), requireNotNull(it.en))
             },

--- a/data/db/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/db/entity/SessionEntity.kt
+++ b/data/db/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/db/entity/SessionEntity.kt
@@ -11,6 +11,7 @@ interface SessionEntity {
     val language: LanguageEntity?
     val category: CategoryEntity?
     val intendedAudience: String?
+    val isInterpretationTarget: Boolean
     val room: RoomEntity?
     val message: MessageEntity?
     val isServiceSession: Boolean

--- a/data/repository-impl/src/main/java/io/github/droidkaigi/confsched2019/data/repository/mapper/SessionMappers.kt
+++ b/data/repository-impl/src/main/java/io/github/droidkaigi/confsched2019/data/repository/mapper/SessionMappers.kt
@@ -64,6 +64,7 @@ fun SessionWithSpeakers.toSession(
                 )
             },
             intendedAudience = session.intendedAudience,
+            isInterpretationTarget = session.isInterpretationTarget,
             isFavorited = favList!!.map { it.toString() }.contains(session.id),
             speakers = speakers,
             message = session.message?.let {

--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -184,11 +184,11 @@
                         style="@style/Widget.MaterialComponents.Chip.Action"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:visibility="@{session.isInterpretationTarget ? View.VISIBLE : View.GONE}"
                         android:text="@string/session_simultaneous_interpretation"
                         android:textAppearance="?textAppearanceCaption"
                         android:textColor="@color/white"
                         app:chipBackgroundColor="#7982e1"
+                        app:visibleGone="@{session.isInterpretationTarget}"
                         />
 
                     <com.google.android.material.chip.Chip

--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -6,7 +6,7 @@
     >
 
     <data>
-
+        <import type="android.view.View"/>
         <variable
             name="session"
             type="io.github.droidkaigi.confsched2019.model.Session.SpeechSession"
@@ -177,6 +177,18 @@
                         android:textColor="@color/white"
                         app:chipBackgroundColor="#7982e1"
                         tools:text="Japanese"
+                        />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/simultaneous_interpretation_chip"
+                        style="@style/Widget.MaterialComponents.Chip.Action"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:visibility="@{session.isInterpretationTarget ? View.VISIBLE : View.GONE}"
+                        android:text="@string/session_simultaneous_interpretation"
+                        android:textAppearance="?textAppearanceCaption"
+                        android:textColor="@color/white"
+                        app:chipBackgroundColor="#7982e1"
                         />
 
                     <com.google.android.material.chip.Chip

--- a/feature/session/src/main/res/layout/item_session.xml
+++ b/feature/session/src/main/res/layout/item_session.xml
@@ -118,12 +118,12 @@
                 android:clickable="false"
                 android:ellipsize="end"
                 android:enabled="false"
-                android:visibility="@{session.isInterpretationTarget ? View.VISIBLE : View.GONE}"
                 android:text="@string/session_simultaneous_interpretation"
                 android:textAppearance="@style/TextAppearance.App.Caption"
                 android:textColor="@color/white"
                 app:chipBackgroundColor="#7982e1"
                 app:chipMinTouchTargetSize="0dp"
+                app:visibleGone="@{session.isInterpretationTarget}"
                 />
 
             <com.google.android.material.chip.Chip

--- a/feature/session/src/main/res/layout/item_session.xml
+++ b/feature/session/src/main/res/layout/item_session.xml
@@ -6,7 +6,7 @@
     >
 
     <data>
-
+        <import type="android.view.View"/>
         <variable
             name="session"
             type="io.github.droidkaigi.confsched2019.model.Session.SpeechSession"
@@ -109,6 +109,21 @@
                 app:chipBackgroundColor="#7982e1"
                 app:chipMinTouchTargetSize="0dp"
                 tools:text="Japanese"
+                />
+            <com.google.android.material.chip.Chip
+                android:id="@+id/simultaneous_interpretation_chip"
+                style="@style/Widget.MaterialComponents.Chip.Action"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:clickable="false"
+                android:ellipsize="end"
+                android:enabled="false"
+                android:visibility="@{session.isInterpretationTarget ? View.VISIBLE : View.GONE}"
+                android:text="@string/session_simultaneous_interpretation"
+                android:textAppearance="@style/TextAppearance.App.Caption"
+                android:textColor="@color/white"
+                app:chipBackgroundColor="#7982e1"
+                app:chipMinTouchTargetSize="0dp"
                 />
 
             <com.google.android.material.chip.Chip

--- a/feature/session/src/main/res/values-ja/strings.xml
+++ b/feature/session/src/main/res/values-ja/strings.xml
@@ -7,4 +7,5 @@
     <string name="session_detail_go_to_survey">回答する</string>
     <string name="session_search_hint">検索する…</string>
     <string name="session_go_to_survey">アンケートに回答する</string>
+    <string name="session_simultaneous_interpretation">同時通訳</string>
 </resources>

--- a/feature/session/src/main/res/values/strings.xml
+++ b/feature/session/src/main/res/values/strings.xml
@@ -19,4 +19,5 @@
     <string name="session_place" translatable="false">Place</string>
     <string name="session_search_hint">Search…</string>
     <string name="session_go_to_survey">Go to survey</string>
+    <string name="session_simultaneous_interpretation">simultaneous interpretation</string>
 </resources>

--- a/feature/session/src/test/java/io/github/droidkaigi/confsched2019/SessionDummyDatas.kt
+++ b/feature/session/src/test/java/io/github/droidkaigi/confsched2019/SessionDummyDatas.kt
@@ -37,6 +37,7 @@ fun dummySessionData(): List<Session> {
             language = LocaledString("英語", "English"),
             category = Category(10, LocaledString("ツール", "Tool")),
             intendedAudience = "extream",
+            isInterpretationTarget = true,
             isFavorited = true,
             speakers = listOf(),
             message = SessionMessage("部屋移動", "room moved")
@@ -60,6 +61,7 @@ fun firstDummySpeechSession(): Session.SpeechSession {
         language = LocaledString("日本語", "Japanese"),
         category = Category(id = 10, name = LocaledString("アーキテクチャ", "App Architecture")),
         intendedAudience = "intermediate",
+        isInterpretationTarget = false,
         isFavorited = false,
         speakers = listOf(),
         message = null

--- a/model/src/commonMain/kotlin/Session.kt
+++ b/model/src/commonMain/kotlin/Session.kt
@@ -22,6 +22,7 @@ sealed class Session(
         val language: LocaledString,
         val category: Category,
         val intendedAudience: String?,
+        val isInterpretationTarget: Boolean,
         val isFavorited: Boolean,
         val speakers: List<Speaker>,
         val message: SessionMessage?


### PR DESCRIPTION
## Issue
- close #152

## Overview (Required)
- show simultaneous interpretation tag on session view when `interpretationTarget` is true.

## Screenshot
<img src="https://user-images.githubusercontent.com/1964200/50844917-12600d00-13af-11e9-9b4c-55949a4ef7db.png" width="300" />

