### PR TITLE
Revise the Firebase product names to use formal ones in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ This project uses some modern Android libraries and source codes.
   * Coroutines
   * Serialization
 * [Firebase](https://firebase.google.com/) (Google)
-  * Auth
-  * Firestore
+  * Authentication
+  * Cloud Firestore
 * [Dagger 2](https://google.github.io/dagger/)
   * Core (Google)
   * AndroidSupport (Google)


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- Use formal names for Firebase product in README.
  - `Auth` -> `Authentication`
  - `Firestore` -> `Cloud Firestore`
