### PR TITLE
Added toolbar on license screen

### DIFF
--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2019/about/ui/item/AboutSection.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2019/about/ui/item/AboutSection.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2019.about.ui.item
 import android.widget.Toast
 import androidx.fragment.app.FragmentActivity
 import androidx.navigation.Navigation
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import com.xwray.groupie.Section
 import io.github.droidkaigi.confsched2019.about.R
 import io.github.droidkaigi.confsched2019.system.actioncreator.ActivityActionCreator
@@ -41,6 +42,7 @@ class AboutSection @Inject constructor(
                 ) {
                     Navigation.findNavController(activity, R.id.root_nav_host_fragment)
                         .navigate(R.id.licenses)
+                    OssLicensesMenuActivity.setActivityTitle(it.getString(R.string.about_license))
                 },
                 AboutItem(
                     R.string.about_app_version,

--- a/frontend/android/src/main/AndroidManifest.xml
+++ b/frontend/android/src/main/AndroidManifest.xml
@@ -23,6 +23,10 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+            android:theme="@style/AppTheme.WithActionBar"
+            />
     </application>
 
 </manifest>

--- a/frontendcomponent/androidcomponent/src/main/res/values/themes.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values/themes.xml
@@ -24,6 +24,12 @@
         <item name="textAppearanceCaption">@style/TextAppearance.App.Caption</item>
     </style>
 
+    <style name="AppTheme.WithActionBar">
+        <item name="windowActionBar">true</item>
+        <item name="windowNoTitle">false</item>
+        <item name="colorPrimary">@android:color/white</item>
+    </style>
+
     <style name="SearchViewStyle" parent="Widget.AppCompat.SearchView">
         <item name="searchHintIcon">@null</item>
     </style>


### PR DESCRIPTION
## Overview (Required)
- Added toolbar on license screen.

If you do not need a Toolbar on license screen close this PR. 🙏 

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13705006/50868680-f3379e80-13f3-11e9-98ba-4b1f9dac94e6.png" width="300" /> | <img src="https://user-images.githubusercontent.com/13705006/50868681-f3d03500-13f3-11e9-9e0f-1cc2cb397e55.png" width="300" />
