### PR TITLE
Make :model buildable for iOS Framework

### DIFF
--- a/data/api-impl/build.gradle
+++ b/data/api-impl/build.gradle
@@ -15,9 +15,10 @@ kotlin {
     targets {
         fromPreset(presets.android, 'android')
 
-        final def buildForDevice = project.findProperty("device")?.toBoolean() ?: false
-        final def iosPreset = (buildForDevice) ? presets.iosArm64 : presets.iosX64
-        fromPreset(iosPreset, 'ios') {
+        final def iOSTarget = System.getenv('SDK_NAME')?.startsWith("iphoneos") \
+                              ? presets.iosArm64 : presets.iosX64
+
+        fromPreset(iOSTarget, 'iOS') {
             compilations.main.outputKinds('FRAMEWORK')
         }
     }

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -9,6 +9,12 @@ kotlin {
     targets {
         fromPreset(presets.android, 'android')
         fromPreset(presets.jvm, 'jvm')
+        final def iOSTarget = System.getenv('SDK_NAME')?.startsWith("iphoneos") \
+                              ? presets.iosArm64 : presets.iosX64
+
+        fromPreset(iOSTarget, 'iOS') {
+            compilations.main.outputKinds('FRAMEWORK')
+        }
     }
     sourceSets {
         commonMain {

--- a/model/src/commonMain/kotlin/LocaleMessage.kt
+++ b/model/src/commonMain/kotlin/LocaleMessage.kt
@@ -2,4 +2,4 @@ package io.github.droidkaigi.confsched2019.model
 
 class LocaleMessage(val enMessage: String, val jaMessage: String)
 
-expect fun LocaleMessage.get(): String
+fun LocaleMessage.get() = if (defaultLang() != Lang.JA) enMessage else jaMessage

--- a/model/src/iosMain/kotlin/io/github/droidkaigi/confsched2019/model/Lang.kt
+++ b/model/src/iosMain/kotlin/io/github/droidkaigi/confsched2019/model/Lang.kt
@@ -1,0 +1,6 @@
+package io.github.droidkaigi.confsched2019.model
+
+import platform.Foundation.NSLocale
+import platform.Foundation.preferredLanguages
+
+actual fun defaultLang() = if (NSLocale.preferredLanguages.first() == "ja") Lang.JA else Lang.EN

--- a/model/src/jvmMain/kotlin/LocaleMessage.kt
+++ b/model/src/jvmMain/kotlin/LocaleMessage.kt
@@ -1,3 +1,0 @@
-package io.github.droidkaigi.confsched2019.model
-
-actual fun LocaleMessage.get() = if (defaultLang() != Lang.JA) enMessage else jaMessage


### PR DESCRIPTION
## Issue
- A part of #136

## Overview (Required)
- Now `:model` module can build for iOS Framework! 🎉
    - `./gradlew :model:build` and you can see `model.framework` in `model/build/bin/ios/main/(debug|release)/framework`
- To use "SDK_NAME" environment variable to detect architecture of preset.

## Links
- http://matsukaz.hatenablog.com/entry/2015/07/06/090933
- https://qiita.com/nomadmonad/items/c3b6d04627df4d966f8e#nslocale%E3%81%AE%E4%BD%95%E3%81%AB%E8%A8%AD%E5%AE%9A%E3%81%95%E3%82%8C%E3%82%8B%E3%81%AE%E3%81%8B

