### PR TITLE
Introduce filter chip animation brought from iosched 2018

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionPageFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionPageFragment.kt
@@ -35,6 +35,8 @@ import io.github.droidkaigi.confsched2019.session.ui.store.SessionPagesStore
 import io.github.droidkaigi.confsched2019.session.ui.widget.DaggerFragment
 import io.github.droidkaigi.confsched2019.system.store.SystemStore
 import io.github.droidkaigi.confsched2019.widget.BottomSheetBehavior
+import io.github.droidkaigi.confsched2019.widget.FilterChip
+import io.github.droidkaigi.confsched2019.widget.onCheckedChanged
 import me.tatarka.injectedvmprovider.InjectedViewModelProviders
 import me.tatarka.injectedvmprovider.ktx.injectedViewModelProvider
 import javax.inject.Inject
@@ -176,7 +178,7 @@ class SessionPageFragment : DaggerFragment() {
                     R.layout.layout_chip,
                     this,
                     false
-                ) as Chip
+                ) as FilterChip
                 chip.apply {
                     text = chipText(item)
                     tag = item
@@ -191,43 +193,43 @@ class SessionPageFragment : DaggerFragment() {
     private fun applyFilters() {
         val filterRooms = sessionPagesStore.filtersValue.rooms
         binding.sessionsFilterRoomChip.forEach {
-            val chip = it as? Chip ?: return@forEach
+            val chip = it as? FilterChip ?: return@forEach
             val room = it.tag as? Room ?: return@forEach
-            chip.setOnCheckedChangeListener(null)
+            chip.onCheckedChangeListener = null
             if (filterRooms.isNotEmpty()) {
                 chip.isChecked = filterRooms.contains(room)
             } else {
                 chip.isChecked = false
             }
-            chip.setOnCheckedChangeListener { _, isChecked ->
+            chip.onCheckedChanged { _, isChecked ->
                 sessionPagesActionCreator.changeFilter(room, isChecked)
             }
         }
         val filterCategorys = sessionPagesStore.filtersValue.categories
         binding.sessionsFilterCategoryChip.forEach {
-            val chip = it as? Chip ?: return@forEach
+            val chip = it as? FilterChip ?: return@forEach
             val category = it.tag as? Category ?: return@forEach
-            chip.setOnCheckedChangeListener(null)
+            chip.onCheckedChangeListener = null
             if (filterCategorys.isNotEmpty()) {
                 chip.isChecked = filterCategorys.contains(category)
             } else {
                 chip.isChecked = false
             }
-            chip.setOnCheckedChangeListener { _, isChecked ->
+            chip.onCheckedChanged { _, isChecked ->
                 sessionPagesActionCreator.changeFilter(category, isChecked)
             }
         }
         val filterLangs = sessionPagesStore.filtersValue.langs
         binding.sessionsFilterLangChip.forEach {
-            val chip = it as? Chip ?: return@forEach
+            val chip = it as? FilterChip ?: return@forEach
             val lang = it.tag as? Lang ?: return@forEach
-            chip.setOnCheckedChangeListener(null)
+            chip.onCheckedChangeListener = null
             if (filterLangs.isNotEmpty()) {
                 chip.isChecked = filterLangs.contains(lang)
             } else {
                 chip.isChecked = false
             }
-            chip.setOnCheckedChangeListener { _, isChecked ->
+            chip.onCheckedChanged { _, isChecked ->
                 sessionPagesActionCreator.changeFilter(lang, isChecked)
             }
         }

--- a/feature/session/src/main/res/layout/fragment_session_page.xml
+++ b/feature/session/src/main/res/layout/fragment_session_page.xml
@@ -69,12 +69,11 @@
 
                 <com.google.android.material.chip.ChipGroup
                     android:id="@+id/sessions_filter_room_chip"
+                    style="@style/Widget.App.ChipGroup.SessionFilter"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    app:chipSpacingHorizontal="4dp"
-                    app:chipSpacingVertical="8dp"
-                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintEnd_toEndOf="@id/sessions_filter_reset"
                     app:layout_constraintStart_toStartOf="@id/sessions_filter_title"
                     app:layout_constraintTop_toBottomOf="@id/sessions_filter_room_title"
                     />
@@ -93,12 +92,11 @@
 
                 <com.google.android.material.chip.ChipGroup
                     android:id="@+id/sessions_filter_lang_chip"
+                    style="@style/Widget.App.ChipGroup.SessionFilter"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    app:chipSpacingHorizontal="4dp"
-                    app:chipSpacingVertical="8dp"
-                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintEnd_toEndOf="@id/sessions_filter_reset"
                     app:layout_constraintStart_toStartOf="@id/sessions_filter_title"
                     app:layout_constraintTop_toBottomOf="@id/sessions_filter_lang_title"
                     />
@@ -118,12 +116,11 @@
 
                 <com.google.android.material.chip.ChipGroup
                     android:id="@+id/sessions_filter_category_chip"
+                    style="@style/Widget.App.ChipGroup.SessionFilter"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    app:chipSpacingHorizontal="4dp"
-                    app:chipSpacingVertical="8dp"
-                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintEnd_toEndOf="@id/sessions_filter_reset"
                     app:layout_constraintStart_toStartOf="@id/sessions_filter_title"
                     app:layout_constraintTop_toBottomOf="@id/sessions_filter_category_title"
                     />

--- a/feature/session/src/main/res/layout/layout_chip.xml
+++ b/feature/session/src/main/res/layout/layout_chip.xml
@@ -1,16 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- TODO Use: https://github.com/google/iosched/blob/2696fc7e06826ba2db72de243f0d63f83f4a29b5/mobile/src/main/java/com/google/samples/apps/iosched/ui/schedule/filters/EventFilterView.kt -->
-<com.google.android.material.chip.Chip
+<io.github.droidkaigi.confsched2019.widget.FilterChip
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/Widget.MaterialComponents.Chip.Filter"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:color="@color/white"
     android:textColor="@color/white"
-    app:chipBackgroundColor="@color/colorPrimary"
-    app:chipMinTouchTargetSize="0dp"
-    app:chipStrokeColor="@color/white"
-    app:chipStrokeWidth="1dp"
+    app:selectedTextColor="@color/gray1"
+    app:strokeColor="@color/white"
     tools:text="hoge"
     />

--- a/feature/session/src/main/res/values/styles.xml
+++ b/feature/session/src/main/res/values/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Widget.App.ChipGroup.SessionFilter" parent="Widget.MaterialComponents.ChipGroup">
+        <item name="chipSpacingVertical">8dp</item>
+    </style>
+</resources>

--- a/frontendcomponent/androidcomponent/build.gradle
+++ b/frontendcomponent/androidcomponent/build.gradle
@@ -9,6 +9,7 @@ apply from: rootProject.file('gradle/android.gradle')
 dependencies {
     api project(":model")
     api Dep.AndroidX.design
+    api Dep.AndroidX.coreKtx
     implementation Dep.Kotlin.stdlibJvm
 
     api Dep.Dagger.androidSupport

--- a/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/widget/EventFilterView.kt
+++ b/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/widget/EventFilterView.kt
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.samples.apps.iosched.ui.schedule.filters
+
+import android.animation.ValueAnimator
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Outline
+import android.graphics.Paint
+import android.graphics.Paint.ANTI_ALIAS_FLAG
+import android.graphics.Paint.Style.STROKE
+import android.graphics.drawable.Drawable
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.M
+import android.text.Layout.Alignment.ALIGN_NORMAL
+import android.text.StaticLayout
+import android.text.TextPaint
+import android.util.AttributeSet
+import android.view.View
+import android.view.ViewOutlineProvider
+import android.view.animation.AnimationUtils
+import android.widget.Checkable
+import androidx.annotation.ColorInt
+import androidx.core.animation.doOnEnd
+import androidx.core.content.res.getColorOrThrow
+import androidx.core.content.res.getDimensionOrThrow
+import androidx.core.content.res.getDimensionPixelSizeOrThrow
+import androidx.core.content.res.getDrawableOrThrow
+import androidx.core.graphics.ColorUtils
+import androidx.core.graphics.withScale
+import androidx.core.graphics.withTranslation
+import com.google.samples.apps.iosched.R
+import com.google.samples.apps.iosched.util.lerp
+import com.google.samples.apps.iosched.util.textWidth
+
+/**
+ * A custom view for displaying filters. Allows a custom presentation of the tag color and selection
+ * state.
+ */
+class EventFilterView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr), Checkable {
+
+    var color: Int = 0xffff00ff.toInt()
+        set(value) {
+            if (field != value) {
+                field = value
+                dotPaint.color = value
+                postInvalidateOnAnimation()
+            }
+        }
+
+    var selectedTextColor: Int? = null
+
+    var text: CharSequence? = null
+        set(value) {
+            field = value
+            updateContentDescription()
+            requestLayout()
+        }
+
+    var showIcons: Boolean = true
+        set(value) {
+            if (field != value) {
+                field = value
+                requestLayout()
+            }
+        }
+
+    private var progress = 0f
+        set(value) {
+            if (field != value) {
+                field = value
+                postInvalidateOnAnimation()
+                if (value == 0f || value == 1f) {
+                    updateContentDescription()
+                }
+            }
+        }
+
+    private val padding: Int
+
+    private val outlinePaint: Paint
+
+    private val textPaint: TextPaint
+
+    private val dotPaint: Paint
+
+    private val clear: Drawable
+
+    private val touchFeedback: Drawable
+
+    private lateinit var textLayout: StaticLayout
+
+    private var progressAnimator: ValueAnimator? = null
+
+    private val interp =
+        AnimationUtils.loadInterpolator(context, android.R.interpolator.fast_out_slow_in)
+
+    @ColorInt private val defaultTextColor: Int
+
+    init {
+        val a = context.obtainStyledAttributes(
+            attrs,
+            R.styleable.EventFilterView,
+            R.attr.eventFilterViewStyle,
+            R.style.Widget_IOSched_EventFilters
+        )
+        outlinePaint = Paint(ANTI_ALIAS_FLAG).apply {
+            color = a.getColorOrThrow(R.styleable.EventFilterView_android_strokeColor)
+            strokeWidth = a.getDimensionOrThrow(R.styleable.EventFilterView_outlineWidth)
+            style = STROKE
+        }
+        defaultTextColor = a.getColorOrThrow(R.styleable.EventFilterView_android_textColor)
+        textPaint = TextPaint(ANTI_ALIAS_FLAG).apply {
+            color = defaultTextColor
+            textSize = a.getDimensionOrThrow(R.styleable.EventFilterView_android_textSize)
+        }
+        dotPaint = Paint(ANTI_ALIAS_FLAG)
+        clear = a.getDrawableOrThrow(R.styleable.EventFilterView_clearIcon).apply {
+            setBounds(
+                -intrinsicWidth / 2, -intrinsicHeight / 2, intrinsicWidth / 2, intrinsicHeight / 2
+            )
+        }
+        touchFeedback = a.getDrawableOrThrow(R.styleable.EventFilterView_foreground).apply {
+            callback = this@EventFilterView
+        }
+        padding = a.getDimensionPixelSizeOrThrow(R.styleable.EventFilterView_android_padding)
+        isChecked = a.getBoolean(R.styleable.EventFilterView_android_checked, false)
+        showIcons = a.getBoolean(R.styleable.EventFilterView_showIcons, true)
+        a.recycle()
+        clipToOutline = true
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val nonTextWidth = (4 * padding) +
+            (2 * outlinePaint.strokeWidth).toInt() +
+            if (showIcons) clear.intrinsicWidth else 0
+        val availableTextWidth = when (MeasureSpec.getMode(widthMeasureSpec)) {
+            MeasureSpec.EXACTLY -> MeasureSpec.getSize(widthMeasureSpec) - nonTextWidth
+            MeasureSpec.AT_MOST -> MeasureSpec.getSize(widthMeasureSpec) - nonTextWidth
+            MeasureSpec.UNSPECIFIED -> Int.MAX_VALUE
+            else -> Int.MAX_VALUE
+        }
+        createLayout(availableTextWidth)
+        val w = nonTextWidth + textLayout.textWidth()
+        val h = padding + textLayout.height + padding
+        setMeasuredDimension(w, h)
+        outlineProvider = object : ViewOutlineProvider() {
+            override fun getOutline(view: View, outline: Outline) {
+                outline.setRoundRect(0, 0, w, h, h / 2f)
+            }
+        }
+        touchFeedback.setBounds(0, 0, w, h)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        val strokeWidth = outlinePaint.strokeWidth
+        val iconRadius = clear.intrinsicWidth / 2f
+        val halfStroke = strokeWidth / 2f
+        val rounding = (height - strokeWidth) / 2f
+
+        // Outline
+        if (progress < 1f) {
+            canvas.drawRoundRect(
+                halfStroke,
+                halfStroke,
+                width - halfStroke,
+                height - halfStroke,
+                rounding,
+                rounding,
+                outlinePaint
+            )
+        }
+
+        // Tag color dot/background
+        if (showIcons) {
+            // Draws beyond bounds and relies on clipToOutline to enforce pill shape
+            val dotRadius = lerp(
+                strokeWidth + iconRadius,
+                width.toFloat(),
+                progress
+            )
+            canvas.drawCircle(strokeWidth + padding + iconRadius, height / 2f, dotRadius, dotPaint)
+        } else {
+            canvas.drawRoundRect(
+                halfStroke,
+                halfStroke,
+                width - halfStroke,
+                height - halfStroke,
+                rounding,
+                rounding,
+                dotPaint
+            )
+        }
+
+        // Text
+        val textX = if (showIcons) {
+            lerp(
+                strokeWidth + padding + clear.intrinsicWidth + padding,
+                strokeWidth + padding * 2f,
+                progress
+            )
+        } else {
+            strokeWidth + padding * 2f
+        }
+        val selectedColor = selectedTextColor
+        textPaint.color = if (selectedColor != null && selectedColor != 0 && progress > 0) {
+            ColorUtils.blendARGB(defaultTextColor, selectedColor, progress)
+        } else {
+            defaultTextColor
+        }
+        canvas.withTranslation(
+            x = textX,
+            y = (height - textLayout.height) / 2f
+        ) {
+            textLayout.draw(canvas)
+        }
+
+        // Clear icon
+        if (showIcons && progress > 0f) {
+            canvas.withTranslation(
+                x = width - strokeWidth - padding - iconRadius,
+                y = height / 2f
+            ) {
+                canvas.withScale(progress, progress) {
+                    clear.draw(canvas)
+                }
+            }
+        }
+
+        // Touch feedback
+        touchFeedback.draw(canvas)
+    }
+
+    /**
+     * Starts the animation to enable/disable a filter and invokes a function when done.
+     */
+    fun animateCheckedAndInvoke(checked: Boolean, onEnd: (() -> Unit)?) {
+        val newProgress = if (checked) 1f else 0f
+        if (newProgress != progress) {
+            progressAnimator?.cancel()
+            progressAnimator = ValueAnimator.ofFloat(progress, newProgress).apply {
+                addUpdateListener {
+                    progress = it.animatedValue as Float
+                }
+                doOnEnd {
+                    progress = newProgress
+                    onEnd?.invoke()
+                }
+                interpolator = interp
+                duration = if (checked) SELECTING_DURATION else DESELECTING_DURATION
+                start()
+            }
+        }
+    }
+
+    override fun isChecked() = progress == 1f
+
+    override fun toggle() {
+        progress = if (progress == 0f) 1f else 0f
+    }
+
+    override fun setChecked(checked: Boolean) {
+        progress = if (checked) 1f else 0f
+    }
+
+    override fun verifyDrawable(who: Drawable?): Boolean {
+        return super.verifyDrawable(who) || who == touchFeedback
+    }
+
+    override fun drawableStateChanged() {
+        super.drawableStateChanged()
+        touchFeedback.state = drawableState
+    }
+
+    override fun jumpDrawablesToCurrentState() {
+        super.jumpDrawablesToCurrentState()
+        touchFeedback.jumpToCurrentState()
+    }
+
+    override fun drawableHotspotChanged(x: Float, y: Float) {
+        super.drawableHotspotChanged(x, y)
+        touchFeedback.setHotspot(x, y)
+    }
+
+    private fun createLayout(textWidth: Int) {
+        textLayout = if (SDK_INT >= M) {
+            StaticLayout.Builder.obtain(text, 0, text?.length!!, textPaint, textWidth).build()
+        } else {
+            StaticLayout(text, textPaint, textWidth, ALIGN_NORMAL, 1f, 0f, true)
+        }
+    }
+
+    private fun updateContentDescription() {
+        val desc = if (isChecked) R.string.a11y_filter_applied else R.string.a11y_filter_not_applied
+        contentDescription = resources.getString(desc, text)
+    }
+
+    companion object {
+        private const val SELECTING_DURATION = 350L
+        private const val DESELECTING_DURATION = 200L
+    }
+}

--- a/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/widget/FilterChip.kt
+++ b/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/widget/FilterChip.kt
@@ -82,13 +82,20 @@ class FilterChip @JvmOverloads constructor(
             }
         }
 
+    var onCheckedChangeListener: OnCheckedChangeListener? = null
+
     private var progress = 0f
         set(value) {
             if (field != value) {
+                val prevChecked = isChecked
                 field = value
+                val newChecked = isChecked
                 postInvalidateOnAnimation()
                 if (value == 0f || value == 1f) {
                     updateContentDescription()
+                }
+                if (newChecked != prevChecked) {
+                    onCheckedChangeListener?.onCheckedChanged(this, newChecked)
                 }
             }
         }
@@ -147,6 +154,7 @@ class FilterChip @JvmOverloads constructor(
         showIcons = a.getBoolean(R.styleable.FilterChip_showIcons, true)
         a.recycle()
         clipToOutline = true
+        setOnClickListener { toggleWithAnimation() }
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
@@ -275,11 +283,19 @@ class FilterChip @JvmOverloads constructor(
     override fun isChecked() = progress == 1f
 
     override fun toggle() {
-        progress = if (progress == 0f) 1f else 0f
+        progress = if (isChecked) 0f else 1f
     }
 
     override fun setChecked(checked: Boolean) {
         progress = if (checked) 1f else 0f
+    }
+
+    fun toggleWithAnimation() {
+        setCheckedWithAnimation(!isChecked)
+    }
+
+    fun setCheckedWithAnimation(checked: Boolean) {
+        animateCheckedAndInvoke(checked, null)
     }
 
     override fun verifyDrawable(who: Drawable): Boolean {
@@ -330,8 +346,20 @@ class FilterChip @JvmOverloads constructor(
         return width.toInt()
     }
 
+    interface OnCheckedChangeListener {
+        fun onCheckedChanged(chip: FilterChip, isChecked: Boolean)
+    }
+
     companion object {
         private const val SELECTING_DURATION = 350L
         private const val DESELECTING_DURATION = 200L
+    }
+}
+
+fun FilterChip.onCheckedChanged(action: (FilterChip, Boolean) -> Unit) {
+    onCheckedChangeListener = object : FilterChip.OnCheckedChangeListener {
+        override fun onCheckedChanged(chip: FilterChip, isChecked: Boolean) {
+            action(chip, isChecked)
+        }
     }
 }

--- a/frontendcomponent/androidcomponent/src/main/res/drawable/tag_clear.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/drawable/tag_clear.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2018 Google LLC
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="@dimen/tag_dot_size"
+    android:height="@dimen/tag_dot_size"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillAlpha="0.8"
+        android:fillColor="#fff"
+        android:pathData="M12,0 A12,12, 0 1,1 12,24 A12,12, 0 1,1 12,0 z" />
+    <path
+        android:pathData="M7,7L17,17M17,7L7,17Z"
+        android:strokeAlpha="0.5"
+        android:strokeColor="#000"
+        android:strokeWidth="2" />
+</vector>

--- a/frontendcomponent/androidcomponent/src/main/res/drawable/tag_clear.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/drawable/tag_clear.xml
@@ -1,32 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2018 Google LLC
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~     https://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="@dimen/tag_dot_size"
-    android:height="@dimen/tag_dot_size"
-    android:viewportWidth="24.0"
-    android:viewportHeight="24.0">
+        android:width="12dp"
+        android:height="12dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
     <path
-        android:fillAlpha="0.8"
-        android:fillColor="#fff"
-        android:pathData="M12,0 A12,12, 0 1,1 12,24 A12,12, 0 1,1 12,0 z" />
-    <path
-        android:pathData="M7,7L17,17M17,7L7,17Z"
-        android:strokeAlpha="0.5"
-        android:strokeColor="#000"
-        android:strokeWidth="2" />
+        android:fillColor="?android:attr/textColorPrimary"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
 </vector>

--- a/frontendcomponent/androidcomponent/src/main/res/values-ja/strings.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values-ja/strings.xml
@@ -6,6 +6,6 @@
     <string name="about_label">Droidkaigiとは</string>
     <string name="sponsor_label">スポンサーページ</string>
     <string name="survey_label">全体アンケート</string>
-    <string name="description_filter_applied">フィルター%1sを適用</string>
-    <string name="description_filter_not_applied">フィルター%1sを解除</string>
+    <string name="description_filter_applied">フィルター%1$sを適用</string>
+    <string name="description_filter_not_applied">フィルター%1$sを解除</string>
 </resources>

--- a/frontendcomponent/androidcomponent/src/main/res/values-ja/strings.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values-ja/strings.xml
@@ -6,4 +6,6 @@
     <string name="about_label">Droidkaigiとは</string>
     <string name="sponsor_label">スポンサーページ</string>
     <string name="survey_label">全体アンケート</string>
+    <string name="description_filter_applied">フィルター%1sを適用</string>
+    <string name="description_filter_not_applied">フィルター%1sを解除</string>
 </resources>

--- a/frontendcomponent/androidcomponent/src/main/res/values/attrs.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values/attrs.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <attr name="eventFilterViewStyle" format="reference"/>
+    <attr name="filterChipStyle" format="reference"/>
 
-    <declare-styleable name="EventFilterView">
+    <declare-styleable name="FilterChip">
         <attr name="android:checked"/>
         <attr name="android:text"/>
         <attr name="android:textColor"/>
         <attr name="android:textSize"/>
         <attr name="android:color"/>
         <attr name="android:padding"/>
-        <attr name="android:strokeColor"/>
-        <attr name="outlineWidth" format="dimension"/>
+        <attr name="strokeColor"/>
+        <attr name="strokeWidth"/>
+        <attr name="selectedTextColor" format="color"/>
         <attr name="clearIcon" format="reference"/>
         <attr name="foreground" format="reference"/>
         <attr name="showIcons" format="boolean"/>

--- a/frontendcomponent/androidcomponent/src/main/res/values/attrs.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values/attrs.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <attr name="eventFilterViewStyle" format="reference"/>
+
+    <declare-styleable name="EventFilterView">
+        <attr name="android:checked"/>
+        <attr name="android:text"/>
+        <attr name="android:textColor"/>
+        <attr name="android:textSize"/>
+        <attr name="android:color"/>
+        <attr name="android:padding"/>
+        <attr name="android:strokeColor"/>
+        <attr name="outlineWidth" format="dimension"/>
+        <attr name="clearIcon" format="reference"/>
+        <attr name="foreground" format="reference"/>
+        <attr name="showIcons" format="boolean"/>
+    </declare-styleable>
+</resources>

--- a/frontendcomponent/androidcomponent/src/main/res/values/strings.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values/strings.xml
@@ -19,4 +19,7 @@
     <string name="search_label" translatable="false">Search</string>
     <!-- Setting -->
     <string name="setting_label" translatable="false">Setting</string>
+    <!-- Widgets -->
+    <string name="a11y_filter_applied" translation_description="Alternative text when an event filter is applies">%1s filter applied</string>
+    <string name="a11y_filter_not_applied" translation_description="Alternative text when an event filter is not applies">%1s filter not applied</string>
 </resources>

--- a/frontendcomponent/androidcomponent/src/main/res/values/strings.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values/strings.xml
@@ -20,6 +20,6 @@
     <!-- Setting -->
     <string name="setting_label" translatable="false">Setting</string>
     <!-- Widgets -->
-    <string name="a11y_filter_applied" translation_description="Alternative text when an event filter is applies">%1s filter applied</string>
-    <string name="a11y_filter_not_applied" translation_description="Alternative text when an event filter is not applies">%1s filter not applied</string>
+    <string name="description_filter_applied">%1s filter applied</string>
+    <string name="description_filter_not_applied">%1s filter not applied</string>
 </resources>

--- a/frontendcomponent/androidcomponent/src/main/res/values/strings.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values/strings.xml
@@ -20,6 +20,6 @@
     <!-- Setting -->
     <string name="setting_label" translatable="false">Setting</string>
     <!-- Widgets -->
-    <string name="description_filter_applied">%1s filter applied</string>
-    <string name="description_filter_not_applied">%1s filter not applied</string>
+    <string name="description_filter_applied">%1$s filter applied</string>
+    <string name="description_filter_not_applied">%1$s filter not applied</string>
 </resources>

--- a/frontendcomponent/androidcomponent/src/main/res/values/styles.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values/styles.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Widget.IOSched.EventFilters">
-        <item name="android:padding">@dimen/spacing_normal</item>
-        <item name="android:strokeColor">?android:textColorTertiary</item>
+
+    <style name="Widget.App.FilterChip" parent="">
+        <item name="android:padding">8dp</item>
         <item name="android:textColor">?android:textColorPrimary</item>
         <item name="android:textSize">14sp</item>
-        <item name="outlineWidth">1dp</item>
+        <item name="strokeColor">?android:textColorTertiary</item>
+        <item name="strokeWidth">1dp</item>
         <item name="clearIcon">@drawable/tag_clear</item>
         <item name="foreground">?selectableItemBackground</item>
         <item name="showIcons">true</item>

--- a/frontendcomponent/androidcomponent/src/main/res/values/styles.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values/styles.xml
@@ -1,3 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <style name="Widget.IOSched.EventFilters">
+        <item name="android:padding">@dimen/spacing_normal</item>
+        <item name="android:strokeColor">?android:textColorTertiary</item>
+        <item name="android:textColor">?android:textColorPrimary</item>
+        <item name="android:textSize">14sp</item>
+        <item name="outlineWidth">1dp</item>
+        <item name="clearIcon">@drawable/tag_clear</item>
+        <item name="foreground">?selectableItemBackground</item>
+        <item name="showIcons">true</item>
+    </style>
 </resources>

--- a/frontendcomponent/androidcomponent/src/main/res/values/themes.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values/themes.xml
@@ -13,6 +13,7 @@
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="searchViewStyle">@style/SearchViewStyle</item>
+        <item name="filterChipStyle">@style/Widget.App.FilterChip</item>
 
         <!-- see https://github.com/material-components/material-components-android/blob/2997b6995f32bbd7f7a4f24f4030278a50c15e6f/docs/theming/Typography.md -->
         <item name="textAppearanceHeadline5">@style/TextAppearance.App.Headline5</item>


### PR DESCRIPTION
## Issue
- #52
  - #52 is not completed only with this PR
  - Remaining work: Apply coloring to the chips after design spec is updated. See https://github.com/DroidKaigi/conference-app-2019/issues/52#issuecomment-452365784

## Overview (Required)
- Implemented chip animation of filter chips
  - The animatable chips are implemented by custom view `FilterChip`
  - `FilterChip` is copied from iosched's [`EventFilterView`](https://github.com/google/iosched/blob/d8bc48b20c132b519879eda3a8e9af120519e159/mobile/src/main/java/com/google/samples/apps/iosched/ui/schedule/filters/EventFilterView.kt)
- I've modified following points of `EventFilterView` for this app
  - Changed class name to `FilterChip`
    - This view can be used for chips of any types of filter. It might be better to remove "event" from class name
    - I don't have strong preference on it, though
  - Removed build errors, made tiny improvements, and adjusted resource names (e376fb378078620a148a6085937e02b5417974f3)
  - Added `OnCheckedChangeListener` interface. Also, Fixed to perform toggle animation by click event (39937881f994d6f7bf2320923bdbea51059b3411)

## Notes
- Because of the implementation of `EventFilterView`, the chips now support line wrapping for long texts
  - It's also possible to make chips keep single line
  - If single line is preferable, please suggest it. I will do that

## Links
- [`EventFilterView.kt`](https://github.com/google/iosched/blob/d8bc48b20c132b519879eda3a8e9af120519e159/mobile/src/main/java/com/google/samples/apps/iosched/ui/schedule/filters/EventFilterView.kt)

## Screenshot
Before | After
:--: | :--:
![svid_20190109_102844_1](https://user-images.githubusercontent.com/12084705/50877814-a8b92080-13f9-11e9-88f5-029d27c9fbc1.gif) | ![svid_20190109_102635_1](https://user-images.githubusercontent.com/12084705/50877813-a8208a00-13f9-11e9-999f-31fafcbe1497.gif)