### PR TITLE
Enable offline build on the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           keys: *all_keys_of_gradle_cache
       - run:
           name: Download Dependencies
-          command: retry_command ./gradlew androidDependenciesExtracs getDependencies
+          command: retry_command ./gradlew androidDependenciesExtra getDependencies
       - save_cache: &save_gradle_cache
           paths:
             - ~/.android
@@ -64,7 +64,7 @@ jobs:
       - run:
           name: Assemble apk
           command: |
-            ./gradlew clean assembleDebug --offline # build with online-mode for now
+            ./gradlew clean assembleDebug --offline
       - store_artifacts:
           path: frontend/android/build/outputs/apk
       - run: *download_dpg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           keys: *all_keys_of_gradle_cache
       - run:
           name: Download Dependencies
-          command: ./gradlew androidDependenciesExtracs getDependencies
+          command: retry_command ./gradlew androidDependenciesExtracs getDependencies
       - save_cache: &save_gradle_cache
           paths:
             - ~/.android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 cache_version_keys: &cache_version_keys
-  CACHE_VERSION_OF_PROJECT_DEPS: v1.1
+  CACHE_VERSION_OF_PROJECT_DEPS: v1.5
   CACHE_VERSION_OF_DANGER_CACHE: v1
 
 cache_keys:
@@ -8,13 +8,11 @@ cache_keys:
     keys: &all_keys_of_gradle_cache
       - *primary_key_of_gradle_cache
       - gradle-cache-{{ checksum "~/CACHE_VERSION_OF_PROJECT_DEPS" }}-
-      - gradle-cache-
   danger_cache:
     primary: &primary_key_of_danger_cache danger-cache-{{ checksum "~/CACHE_VERSION_OF_DANGER_CACHE" }}-{{ checksum "~/danger_cache" }}
     keys: &all_keys_of_danger_cache
       - *primary_key_of_danger_cache
       - danger-cache-{{ checksum "~/CACHE_VERSION_OF_DANGER_CACHE" }}-
-      - danger-cache-
 
 docker_env:
   android_defaults: &android_defaults
@@ -56,7 +54,7 @@ jobs:
           keys: *all_keys_of_gradle_cache
       - run:
           name: Download Dependencies
-          command: ./gradlew downloadAllDependencies
+          command: ./gradlew androidDependenciesExtracs getDependencies
       - save_cache: &save_gradle_cache
           paths:
             - ~/.android
@@ -66,7 +64,7 @@ jobs:
       - run:
           name: Assemble apk
           command: |
-            ./gradlew assembleDebug --offline # build with online-mode for now
+            ./gradlew clean assembleDebug --offline # build with online-mode for now
       - store_artifacts:
           path: frontend/android/build/outputs/apk
       - run: *download_dpg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 cache_version_keys: &cache_version_keys
-  CACHE_VERSION_OF_PROJECT_DEPS: v1.5
+  CACHE_VERSION_OF_PROJECT_DEPS: v2
   CACHE_VERSION_OF_DANGER_CACHE: v1
 
 cache_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 cache_version_keys: &cache_version_keys
-  CACHE_VERSION_OF_PROJECT_DEPS: v1
+  CACHE_VERSION_OF_PROJECT_DEPS: v1.1
   CACHE_VERSION_OF_DANGER_CACHE: v1
 
 cache_keys:
@@ -56,18 +56,17 @@ jobs:
           keys: *all_keys_of_gradle_cache
       - run:
           name: Download Dependencies
-          command: ./gradlew androidDependencies
+          command: ./gradlew downloadAllDependencies
       - save_cache: &save_gradle_cache
           paths:
             - ~/.android
             - ~/.gradle
             - .gradle
-            - ~/.m2
           key: *primary_key_of_gradle_cache
       - run:
           name: Assemble apk
           command: |
-            ./gradlew assembleDebug # --offline # build with online-mode for now
+            ./gradlew assembleDebug --offline # build with online-mode for now
       - store_artifacts:
           path: frontend/android/build/outputs/apk
       - run: *download_dpg
@@ -108,7 +107,7 @@ jobs:
       - checkout
       - run: *init_bash
       - restore_cache: *restore_gradle_cache
-      - run: ./gradlew testDebugUnitTest lintDebug ktlint --continue
+      - run: ./gradlew testDebugUnitTest lintDebug ktlint --continue --offline
       - run:
           name: Merge junit report files
           command: |

--- a/.circleci/scripts/retry_command
+++ b/.circleci/scripts/retry_command
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eu
+
+: "${MAX_RETRY_COUNT:=3}"
+
+retry() {
+    local retry=0
+
+    while let "$MAX_RETRY_COUNT > $retry"; do
+        let "retry=$retry+1"
+
+        "$@" && exit 0
+
+        sleep 3
+    done
+
+    echo "Failed to process : $@" 1>&2
+    exit 1
+}
+
+retry "$@"

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ allprojects {
                 task downloadAllDependencies(dependsOn: 'androidDependencies') {
                     description 'Download extra dependencies for the CI Gradle Cache'
                     doLast {
-                        configurations.findAll { it.name.matches(/(ktlint|kapt)/) && it.canBeResolved }.files
+                        configurations.findAll { it.name.matches(/(ktlint|kapt|_internal_aapt2_binary)/) && it.canBeResolved }.files
                     }
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -69,10 +69,11 @@ allprojects {
                     args "--android", '-F', 'src/main/**/*.kt', 'src/debug/**/*.kt', 'src/release/**/*.kt'
                 }
 
-                task downloadAllDependencies(dependsOn: 'androidDependencies') {
+                task androidDependenciesExtracs(dependsOn: 'androidDependencies') {
                     description 'Download extra dependencies for the CI Gradle Cache'
                     doLast {
-                        configurations.findAll { it.name.matches(/(ktlint|kapt|_internal_aapt2_binary)/) && it.canBeResolved }.files
+                        // androidDependencies do not touch some configurations
+                        configurations.findAll { it.name.matches(/(ktlint|kapt|_internal_aapt2_binary|lintClassPath)/) && it.canBeResolved }.files
                     }
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ allprojects {
                     args "--android", '-F', 'src/main/**/*.kt', 'src/debug/**/*.kt', 'src/release/**/*.kt'
                 }
 
-                task androidDependenciesExtracs(dependsOn: 'androidDependencies') {
+                task androidDependenciesExtra(dependsOn: 'androidDependencies') {
                     description 'Download extra dependencies for the CI Gradle Cache'
                     doLast {
                         // androidDependencies do not touch some configurations

--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,16 @@ allprojects {
                 }
 
                 task ktlint(type: JavaExec, group: "verification") {
+                    def parameters = ["--android", '--editorconfig', "${rootProject.projectDir}/.editorconfig", "--reporter=checkstyle,output=${buildDir}/ktlint/checkstyle.xml"]
+
+                    if (System.getenv("CI") != "true") {
+                        parameters += "--reporter=html,artifact=me.cassiano:ktlint-html-reporter:0.2.0,output=${buildDir}/ktlint/checkstyle.html"
+                    }
+
+                    parameters += ['src/main/**/*.kt', 'src/debug/**/*.kt', 'src/release/**/*.kt']
+
                     description = 'Check Kotlin code style.'
-                    args "--android", '--editorconfig', "${rootProject.projectDir}/.editorconfig", "--reporter=html,artifact=me.cassiano:ktlint-html-reporter:0.2.0,output=${buildDir}/ktlint/checkstyle.html", "--reporter=checkstyle,output=${buildDir}/ktlint/checkstyle.xml", 'src/main/**/*.kt', 'src/debug/**/*.kt', 'src/release/**/*.kt'
+                    args = parameters
                     // https://github.com/shyiko/ktlint/blob/5fe8d0e203275a1a3337dc9777b50ec2a34a58df/ktlint/src/main/kotlin/com/github/shyiko/ktlint/Main.kt
                     main = 'com.github.shyiko.ktlint.Main'
                     classpath = configurations.ktlint

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,13 @@ allprojects {
                     main = "com.github.shyiko.ktlint.Main"
                     args "--android", '-F', 'src/main/**/*.kt', 'src/debug/**/*.kt', 'src/release/**/*.kt'
                 }
+
+                task downloadAllDependencies(dependsOn: 'androidDependencies') {
+                    description 'Download extra dependencies for the CI Gradle Cache'
+                    doLast {
+                        configurations.findAll { it.name.matches(/(ktlint|kapt)/) && it.canBeResolved }.files
+                    }
+                }
             }
         }
     }
@@ -81,7 +88,6 @@ allprojects {
             }
         }
     }
-
 }
 
 task clean(type: Delete) {

--- a/scripts/danger/Dangerfile.assertions
+++ b/scripts/danger/Dangerfile.assertions
@@ -44,6 +44,6 @@ end
 # LGTM
 begin
   if status_report[:errors].length.zero? && status_report[:warnings].length.zero?
-    markdown("ALL GREEN :100:")
+    markdown("Asserted successfully. :100:")
   end
 end

--- a/scripts/danger/Dangerfile.assertions
+++ b/scripts/danger/Dangerfile.assertions
@@ -24,9 +24,9 @@ begin
   if File.exists?(ENV.fetch('MERGED_JUNIT_RESULT_FILE'))
     # junit report
     junit.parse ENV.fetch('MERGED_JUNIT_RESULT_FILE')
-    fail("Failed tests found") unless junit.failures.empty?
+    fail("Failed tests found. Please fix test failures.") unless junit.failures.empty?
   else
-    fail("Test results not found")
+    fail("The previous test step failed. Please check the CI log.")
   end
 end
 


### PR DESCRIPTION
## Issue
- #305 

## Overview (Required)
- I know people love faster builds.
- `dependencies` does not download all dependencies, and also nothing will be downloaded as for this project.
- `androidDependencies` does not contain kapt and custom configurations
- So we need a task to download kapt and custom configurations. After that, let's combine it with `androidDependencies`.
- A html reporter was downloaded every time but it was not used on CI

## Links
-
