### PR TITLE
Fix to hide BottomAppBar when session detail can not scroll

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionBottomAppBarBehavior.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionBottomAppBarBehavior.kt
@@ -11,11 +11,15 @@ import com.google.android.material.bottomappbar.BottomAppBar
 class SessionBottomAppBarBehavior(
     context: Context? = null,
     attrs: AttributeSet? = null
-    ) : BottomAppBar.Behavior(context, attrs) {
+) : BottomAppBar.Behavior(context, attrs) {
 
     private var state: Int = STATE_SCROLLED_UP
 
-    override fun onInterceptTouchEvent(parent: CoordinatorLayout, child: BottomAppBar, ev: MotionEvent): Boolean {
+    override fun onInterceptTouchEvent(
+        parent: CoordinatorLayout,
+        child: BottomAppBar,
+        ev: MotionEvent
+    ): Boolean {
         if (child.isShown.not() || ev.action != MotionEvent.ACTION_DOWN) {
             return super.onInterceptTouchEvent(parent, child, ev)
         }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionBottomAppBarBehavior.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionBottomAppBarBehavior.kt
@@ -1,0 +1,53 @@
+package io.github.droidkaigi.confsched2019.session.ui.widget
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.children
+import androidx.core.widget.NestedScrollView
+import com.google.android.material.bottomappbar.BottomAppBar
+
+class SessionBottomAppBarBehavior(
+    context: Context? = null,
+    attrs: AttributeSet? = null
+    ) : BottomAppBar.Behavior(context, attrs) {
+
+    private var state: Int = STATE_SCROLLED_UP
+
+    override fun onInterceptTouchEvent(parent: CoordinatorLayout, child: BottomAppBar, ev: MotionEvent): Boolean {
+        if (child.isShown.not() || ev.action != MotionEvent.ACTION_DOWN) {
+            return super.onInterceptTouchEvent(parent, child, ev)
+        }
+
+        // If screen be able not to scrolled, it makes to slide the bottom app bar.
+        if (canScroll(parent).not()) {
+            state = if (state == STATE_SCROLLED_UP) {
+                super.slideDown(child)
+                STATE_SCROLLED_DOWN
+            } else {
+                super.slideUp(child)
+                STATE_SCROLLED_UP
+            }
+        }
+        return super.onInterceptTouchEvent(parent, child, ev)
+    }
+
+    private fun canScroll(parent: CoordinatorLayout): Boolean {
+        val nestedScrollView = if (parent.childCount > 0) {
+            (parent.children.find { it is NestedScrollView } as? NestedScrollView)
+        } else {
+            null
+        }
+        return nestedScrollView?.canScrollVertically(POSITIVE_DIRECTION) ?: true ||
+            nestedScrollView?.canScrollVertically(NEGATIVE_DIRECTION) ?: true
+    }
+
+    companion object {
+        private const val POSITIVE_DIRECTION = 1
+        private const val NEGATIVE_DIRECTION = -1
+
+        private const val STATE_SCROLLED_DOWN = 1
+        private const val STATE_SCROLLED_UP = 2
+    }
+}

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionBottomAppBarBehavior.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionBottomAppBarBehavior.kt
@@ -20,12 +20,12 @@ class SessionBottomAppBarBehavior(
         child: BottomAppBar,
         ev: MotionEvent
     ): Boolean {
-        if (child.isShown.not() || ev.action != MotionEvent.ACTION_DOWN) {
+        if (!child.isShown || ev.action != MotionEvent.ACTION_DOWN) {
             return super.onInterceptTouchEvent(parent, child, ev)
         }
 
         // If screen be able not to scrolled, it makes to slide the bottom app bar.
-        if (canScroll(parent).not()) {
+        if (!canScroll(parent)) {
             state = if (state == STATE_SCROLLED_UP) {
                 super.slideDown(child)
                 STATE_SCROLLED_DOWN

--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -397,6 +397,7 @@
             android:layout_gravity="bottom"
             app:fabAlignmentMode="end"
             app:hideOnScroll="true"
+            app:layout_behavior="@string/session_bottom_appbar_behavior"
             />
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/feature/session/src/main/res/values/strings.xml
+++ b/feature/session/src/main/res/values/strings.xml
@@ -24,4 +24,5 @@
     <string name="session_go_to_survey">Go to survey</string>
     <string name="session_live" translatable="false">Live</string>
     <string name="session_simultaneous_interpretation">simultaneous interpretation</string>
+    <string name="session_bottom_appbar_behavior" translatable="false">io.github.droidkaigi.confsched2019.session.ui.widget.SessionBottomAppBarBehavior</string>
 </resources>


### PR DESCRIPTION
## Issue
- close #153 

## Overview (Required)
- Added SessionBottomAppBarBehavior class
- If screen be able not to scrolled, it makes to slide the bottom app bar

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
