### PR TITLE
Add unit test for AnnouncementActionCreator/AnnouncementStore

### DIFF
--- a/feature/announcement/build.gradle
+++ b/feature/announcement/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     implementation Dep.Groupie.databinding
 
     testImplementation Dep.Test.junit
+    testImplementation Dep.Test.kotlinTestAssertions
+    testImplementation Dep.MockK.jvm
+    testImplementation project(':frontendcomponent:androidtestcomponent')
     androidTestImplementation Dep.Test.testRunner
     androidTestImplementation Dep.Test.espressoCore
 }

--- a/feature/announcement/src/test/java/io/github/droidkaigi/confsched2019/AnnouncementDummyDatas.kt
+++ b/feature/announcement/src/test/java/io/github/droidkaigi/confsched2019/AnnouncementDummyDatas.kt
@@ -1,0 +1,29 @@
+package io.github.droidkaigi.confsched2019
+
+import com.soywiz.klock.DateTime
+import com.soywiz.klock.minutes
+import io.github.droidkaigi.confsched2019.model.Announcement
+
+private val startTime = DateTime.createAdjusted(2019, 2, 7, 10, 0)
+fun dummyAnnouncementsData(): List<Announcement> {
+    return listOf(
+        Announcement(
+            "title1",
+            "content1",
+            startTime,
+            Announcement.Type.NOTIFICATION
+        ),
+        Announcement(
+            "title2",
+            "content2",
+            startTime + 30.minutes,
+            Announcement.Type.ALERT
+        ),
+        Announcement(
+            "title3",
+            "content3",
+            startTime + 60.minutes,
+            Announcement.Type.FEEDBACK
+        )
+    )
+}

--- a/feature/announcement/src/test/java/io/github/droidkaigi/confsched2019/announcement/ui/actioncreator/AnnouncementActionCreatorTest.kt
+++ b/feature/announcement/src/test/java/io/github/droidkaigi/confsched2019/announcement/ui/actioncreator/AnnouncementActionCreatorTest.kt
@@ -1,0 +1,48 @@
+package io.github.droidkaigi.confsched2019.announcement.ui.actioncreator
+
+import androidx.lifecycle.Lifecycle
+import io.github.droidkaigi.confsched2019.action.Action
+import io.github.droidkaigi.confsched2019.data.firestore.FireStore
+import io.github.droidkaigi.confsched2019.dispatcher.Dispatcher
+import io.github.droidkaigi.confsched2019.dummyAnnouncementsData
+import io.github.droidkaigi.confsched2019.ext.android.CoroutinePlugin
+import io.github.droidkaigi.confsched2019.model.LoadingState
+import io.github.droidkaigi.confsched2019.widget.component.TestLifecycleOwner
+import io.mockk.MockKAnnotations
+import io.mockk.Ordering
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.RelaxedMockK
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+
+class AnnouncementActionCreatorTest {
+    @RelaxedMockK lateinit var dispatcher: Dispatcher
+    @RelaxedMockK lateinit var fireStore: FireStore
+
+    @Before fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        CoroutinePlugin.mainDispatcherHandler = { Dispatchers.Default }
+    }
+
+    @Test fun load() = runBlocking {
+        val lifecycleOwner = TestLifecycleOwner().handleEvent(Lifecycle.Event.ON_RESUME)
+        coEvery { fireStore.getAnnouncements() } returns dummyAnnouncementsData()
+        val announcementActionCreator = AnnouncementActionCreator(
+            dispatcher,
+            fireStore,
+            lifecycleOwner.lifecycle
+        )
+
+        announcementActionCreator.load()
+
+        coVerify(ordering = Ordering.SEQUENCE) {
+            dispatcher.dispatch(Action.AnnouncementLoadingStateChanged(LoadingState.LOADING))
+            fireStore.getAnnouncements()
+            dispatcher.dispatch(Action.AnnouncementLoaded(dummyAnnouncementsData()))
+            dispatcher.dispatch(Action.AnnouncementLoadingStateChanged(LoadingState.LOADED))
+        }
+    }
+}

--- a/feature/announcement/src/test/java/io/github/droidkaigi/confsched2019/announcement/ui/store/AnnouncementStoreTest.kt
+++ b/feature/announcement/src/test/java/io/github/droidkaigi/confsched2019/announcement/ui/store/AnnouncementStoreTest.kt
@@ -1,0 +1,60 @@
+package io.github.droidkaigi.confsched2019.announcement.ui.store
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import io.github.droidkaigi.confsched2019.action.Action
+import io.github.droidkaigi.confsched2019.dispatcher.Dispatcher
+import io.github.droidkaigi.confsched2019.dummyAnnouncementsData
+import io.github.droidkaigi.confsched2019.ext.android.CoroutinePlugin
+import io.github.droidkaigi.confsched2019.ext.android.changedForever
+import io.github.droidkaigi.confsched2019.model.Announcement
+import io.github.droidkaigi.confsched2019.model.LoadingState
+import io.mockk.MockKAnnotations
+import io.mockk.mockk
+import io.mockk.verifySequence
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class AnnouncementStoreTest {
+    @JvmField @Rule val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Before fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        CoroutinePlugin.mainDispatcherHandler = { Dispatchers.Default }
+    }
+
+    @Test fun loadingState() = runBlocking {
+        val dispatcher = Dispatcher()
+        val announcementStore = AnnouncementStore(dispatcher)
+        val observer = mockk<(LoadingState?) -> Unit>(relaxed = true)
+
+        announcementStore.loadingState.changedForever(observer)
+
+        dispatcher.dispatch(Action.AnnouncementLoadingStateChanged(LoadingState.LOADING))
+        dispatcher.dispatch(Action.AnnouncementLoadingStateChanged(LoadingState.LOADED))
+
+        verifySequence {
+            observer(LoadingState.LOADING)
+            observer(LoadingState.LOADED)
+        }
+    }
+
+    @Test fun announcements() = runBlocking {
+        val dispatcher = Dispatcher()
+        val announcementStore = AnnouncementStore(dispatcher)
+        val observer: (List<Announcement>) -> Unit = mockk(relaxed = true)
+        announcementStore.announcements.changedForever(observer)
+        val dummyAnnouncements = dummyAnnouncementsData()
+
+        dispatcher.dispatch(
+            Action.AnnouncementLoaded(dummyAnnouncements)
+        )
+
+        verifySequence {
+            observer(emptyList())
+            observer(dummyAnnouncements)
+        }
+    }
+}

--- a/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/action/Action.kt
+++ b/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/action/Action.kt
@@ -52,8 +52,8 @@ sealed class Action {
 
     object UserRegistered : Action()
 
-    class AnnouncementLoadingStateChanged(val loadingState: LoadingState) : Action()
-    class AnnouncementLoaded(val announcements: List<Announcement>) : Action()
+    data class AnnouncementLoadingStateChanged(val loadingState: LoadingState) : Action()
+    data class AnnouncementLoaded(val announcements: List<Announcement>) : Action()
 
     data class SponsorLoadingStateChanged(val loadingState: LoadingState) : Action()
     data class SponsorLoaded(val sponsors: List<SponsorCategory>) : Action()


### PR DESCRIPTION
## Issue
- close #294 

## Overview (Required)
- Add unit test for AnnouncementActionCreator/AnnouncementStore
- Change the action of Announcement to data class

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
