### PR TITLE
Make some modules buildable for iOS Framework.

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -76,7 +76,8 @@ object Dep {
             "org.jetbrains.kotlinx:kotlinx-coroutines-reactive:$coroutinesVersion"
         val coroutinesPlayServices =
             "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutinesVersion"
-        val serialization = "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.8.1-rc13"
+        val serializationCommon = "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.9.1"
+        val serializationIos = "org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:0.9.1"
     }
 
     object Firebase {

--- a/data/api-impl/build.gradle
+++ b/data/api-impl/build.gradle
@@ -43,7 +43,7 @@ kotlin {
             }
         }
         androidTest {
-            dependsOn commonMain
+            dependsOn androidMain
             dependencies {
                 implementation Dep.Test.junit
                 implementation Dep.Test.slf4j

--- a/data/api-impl/build.gradle
+++ b/data/api-impl/build.gradle
@@ -25,8 +25,36 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api project(":data:api")
+            implementation Dep.Kotlin.stdlibCommon
             implementation Dep.Ktor.clientCommon
-            implementation Dep.Kotlin.serialization
+            implementation Dep.Kotlin.serializationCommon
+        }
+        androidMain {
+            dependsOn commonMain
+            dependencies {
+                implementation Dep.Kotlin.stdlibJvm
+                implementation Dep.Ktor.clientAndroid
+                implementation Dep.Ktor.jsonJvm
+                implementation Dep.OkHttp.client
+                implementation Dep.Stetho.stetho
+                implementation Dep.Dagger.core
+                implementation Dep.Dagger.androidSupport
+                implementation Dep.OkHttp.loggingInterceptor
+            }
+        }
+        androidTest {
+            dependsOn commonMain
+            dependencies {
+                implementation Dep.Test.junit
+                implementation Dep.Test.slf4j
+            }
+        }
+        iOSMain {
+            dependsOn commonMain
+            dependencies {
+                implementation Dep.Ktor.clientIos
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:0.9.1"
+            }
         }
     }
 }
@@ -45,20 +73,10 @@ android {
 }
 
 dependencies {
-
-    implementation Dep.Kotlin.stdlibJvm
-    implementation Dep.Ktor.clientAndroid
-    implementation Dep.Ktor.jsonJvm
-    implementation Dep.OkHttp.client
-    implementation Dep.Stetho.stetho
-    implementation Dep.Dagger.core
-    implementation Dep.Dagger.androidSupport
-    implementation Dep.OkHttp.loggingInterceptor
     kapt Dep.Dagger.compiler
     kapt Dep.Dagger.androidProcessor
-
-    testImplementation Dep.Test.junit
-    testImplementation Dep.Test.slf4j
 }
 
-
+configurations {
+    compileClasspath
+}

--- a/data/api-impl/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/ApiEndpoint.kt
+++ b/data/api-impl/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/ApiEndpoint.kt
@@ -1,0 +1,3 @@
+package io.github.droidkaigi.confsched2019.data.api
+
+internal expect fun apiEndpoint(): String

--- a/data/api-impl/src/iosMain/kotlin/io/github/droidkaigi/confsched2019/data/api/ApiComponent.kt
+++ b/data/api-impl/src/iosMain/kotlin/io/github/droidkaigi/confsched2019/data/api/ApiComponent.kt
@@ -1,0 +1,24 @@
+package io.github.droidkaigi.confsched2019.data.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.ios.Ios
+import io.ktor.client.features.UserAgent
+import platform.Foundation.NSBundle
+
+// TODO: Replace with DI tools.
+internal fun generateHttpClient(): HttpClient {
+    val version = NSBundle.mainBundle.objectForInfoDictionaryKey("CFBundleShortVersionString") as String
+    return HttpClient(Ios) {
+        install(UserAgent) {
+            agent = "official-app-2019/$version"
+        }
+    }
+}
+
+fun generateDroidKaigiApi(): DroidKaigiApi {
+    return KtorDroidKaigiApi(generateHttpClient(), apiEndpoint())
+}
+
+fun generateGoogleFormApi(): GoogleFormApi {
+    return KtorGoogleFormApi(generateHttpClient())
+}

--- a/data/api-impl/src/iosMain/kotlin/io/github/droidkaigi/confsched2019/data/api/ApiEndpoint.kt
+++ b/data/api-impl/src/iosMain/kotlin/io/github/droidkaigi/confsched2019/data/api/ApiEndpoint.kt
@@ -1,0 +1,5 @@
+package io.github.droidkaigi.confsched2019.data.api
+
+// TODO: Replace with code getting endpoint from iOS application build configurations.
+//       This is temporally implementation.
+internal actual fun apiEndpoint(): String = "https://droidkaigi2019-dev.appspot.com/api"

--- a/data/api-impl/src/main/java/io/github/droidkaigi/confsched2019/data/api/ApiEndpoint.kt
+++ b/data/api-impl/src/main/java/io/github/droidkaigi/confsched2019/data/api/ApiEndpoint.kt
@@ -1,0 +1,5 @@
+package io.github.droidkaigi.confsched2019.data.api
+
+import io.github.droidkaigi.confsched2019.api.BuildConfig
+
+internal actual fun apiEndpoint(): String = BuildConfig.API_ENDPOINT

--- a/data/api-impl/src/main/java/io/github/droidkaigi/confsched2019/data/api/ApiModule.kt
+++ b/data/api-impl/src/main/java/io/github/droidkaigi/confsched2019/data/api/ApiModule.kt
@@ -37,7 +37,7 @@ internal abstract class ApiModule {
         }
 
         @JvmStatic @Provides @Named("apiEndpoint") fun apiEndpoint(): String {
-            return BuildConfig.API_ENDPOINT
+            return io.github.droidkaigi.confsched2019.data.api.apiEndpoint()
         }
     }
 }

--- a/data/api/build.gradle
+++ b/data/api/build.gradle
@@ -8,6 +8,12 @@ apply from: rootProject.file('gradle/android.gradle')
 kotlin {
     targets {
         fromPreset(presets.android, 'android')
+        final def iOSTarget = System.getenv('SDK_NAME')?.startsWith("iphoneos") \
+                              ? presets.iosArm64 : presets.iosX64
+
+        fromPreset(iOSTarget, 'iOS') {
+            compilations.main.outputKinds('FRAMEWORK')
+        }
     }
     sourceSets {
         commonMain.dependencies {

--- a/data/db-room/build.gradle
+++ b/data/db-room/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     api project(":ext:android-extension")
 
     implementation Dep.Kotlin.stdlibJvm
-    implementation Dep.Kotlin.serialization
+    implementation Dep.Kotlin.serializationCommon
     api Dep.Kotlin.coroutines
     api Dep.AndroidX.Room.runtime
     api Dep.AndroidX.Room.coroutine

--- a/data/db/build.gradle
+++ b/data/db/build.gradle
@@ -8,6 +8,13 @@ apply from: rootProject.file('gradle/android.gradle')
 kotlin {
     targets {
         fromPreset(presets.android, 'android')
+
+        final def iOSTarget = System.getenv('SDK_NAME')?.startsWith("iphoneos") \
+                              ? presets.iosArm64 : presets.iosX64
+
+        fromPreset(iOSTarget, 'iOS') {
+            compilations.main.outputKinds('FRAMEWORK')
+        }
     }
     sourceSets {
         commonMain.dependencies {

--- a/data/firestore/build.gradle
+++ b/data/firestore/build.gradle
@@ -8,6 +8,13 @@ apply from: rootProject.file('gradle/android.gradle')
 kotlin {
     targets {
         fromPreset(presets.android, 'android')
+
+        final def iOSTarget = System.getenv('SDK_NAME')?.startsWith("iphoneos") \
+                              ? presets.iosArm64 : presets.iosX64
+
+        fromPreset(iOSTarget, 'iOS') {
+            compilations.main.outputKinds('FRAMEWORK')
+        }
     }
     sourceSets {
         commonMain.dependencies {

--- a/data/repository-impl/build.gradle
+++ b/data/repository-impl/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     api project(":model")
 
     implementation Dep.Kotlin.stdlibJvm
-    implementation Dep.Kotlin.serialization
+    implementation Dep.Kotlin.serializationCommon
     api Dep.Kotlin.coroutines
     implementation Dep.AndroidX.lifecycleLiveData
     kapt Dep.AndroidX.Room.compiler

--- a/data/repository/build.gradle
+++ b/data/repository/build.gradle
@@ -8,6 +8,13 @@ apply from: rootProject.file('gradle/android.gradle')
 kotlin {
     targets {
         fromPreset(presets.android, 'android')
+
+        final def iOSTarget = System.getenv('SDK_NAME')?.startsWith("iphoneos") \
+                              ? presets.iosArm64 : presets.iosX64
+
+        fromPreset(iOSTarget, 'iOS') {
+            compilations.main.outputKinds('FRAMEWORK')
+        }
     }
     sourceSets {
         commonMain.dependencies {

--- a/ext/log/build.gradle
+++ b/ext/log/build.gradle
@@ -8,6 +8,13 @@ apply from: rootProject.file('gradle/android.gradle')
 kotlin {
     targets {
         fromPreset(presets.android, 'android')
+
+        final def iOSTarget = System.getenv('SDK_NAME')?.startsWith("iphoneos") \
+                              ? presets.iosArm64 : presets.iosX64
+
+        fromPreset(iOSTarget, 'iOS') {
+            compilations.main.outputKinds('FRAMEWORK')
+        }
     }
     sourceSets {
         commonMain.dependencies {


### PR DESCRIPTION
## Issue
- A part of #136

## Overview (Required)
- Now some modules below can build for iOS Frameworks! 📱 
    - `:data:api`
    - `:data:api-impl`
    - `:data:repository`
    - `:data:firestore`
    - `:data:db`
    - `:ext:log`
- How can we implement alternative of `:data:db-room` and `:data:firestore-impl` ...? 🙄 


## Links
- https://qiita.com/nosix/items/50166b1664e6946aafe9

