### PR TITLE
Delete language resources that are not Japanese and English by resConfigs

### DIFF
--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -25,7 +25,7 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
-        resConfigs "en", "ja"
+        resConfigs "ja"
         // For Android Studio Gradle sync
         applicationIdSuffix ".debug"
     }

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -25,6 +25,7 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
+        resConfigs "en", "ja"
         // For Android Studio Gradle sync
         applicationIdSuffix ".debug"
     }


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- Delete language resources that are not Japanese and English by resConfigs
- Support libraries includes string resources other than Japanese and English
- Effect : Reduce apk size

## Links
- https://developer.android.com/studio/build/shrink-code?#unused-alt-resources
- https://qiita.com/tatsuhama/items/814471b79c5d572f77e9
- https://github.com/DroidKaigi/conference-app-2018/pull/129

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/6395886/50911248-d1c9c780-1472-11e9-8410-576ced904ea7.png" width="300" /> | <img src="https://user-images.githubusercontent.com/6395886/50911263-d68e7b80-1472-11e9-82e4-e79b49e545ab.png" width="300" />
