### PR TITLE
Add space on both sides of the session tab.

### DIFF
--- a/feature/session/src/main/res/layout/fragment_session_page.xml
+++ b/feature/session/src/main/res/layout/fragment_session_page.xml
@@ -10,6 +10,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/colorPrimary"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
         tools:context="io.github.droidkaigi.confsched2019.session.ui.SessionPagesFragment"
         >
 


### PR DESCRIPTION
## Issue
- close #315 

## Overview (Required)
- Add 8dp space on both sides of the session tab.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/29793443/50914547-23298500-147a-11e9-9265-8ef213a3ecf1.png" width="300" /> | <img src="https://user-images.githubusercontent.com/29793443/50914557-291f6600-147a-11e9-94d4-e3eb9c7bbff3.png" width="300" />
<img src="https://user-images.githubusercontent.com/29793443/50914607-494f2500-147a-11e9-99e7-56d417078c97.png" width="300" /> | <img src="https://user-images.githubusercontent.com/29793443/50914597-45230780-147a-11e9-9f8d-271aee304bc7.png" width="300" />
