### PR TITLE
use Maven Central mirror hosted on Google Cloud Storage for faster build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ apply from: file('gradle/dependencyGraph.gradle')
 buildscript {
     repositories {
         google()
+        maven { url "https://maven-central-asia.storage-download.googleapis.com/repos/central/data/" }
         jcenter()
         maven { url "https://kotlin.bintray.com/kotlinx" }
         maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
@@ -28,6 +29,7 @@ buildscript {
 allprojects {
     repositories {
         google()
+        maven { url "https://maven-central-asia.storage-download.googleapis.com/repos/central/data/" }
         jcenter()
         maven { url "https://kotlin.bintray.com/kotlinx" }
         maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,12 @@ import dependencies.Dep
 apply from: file('gradle/dependencyGraph.gradle')
 
 buildscript {
+    ext {
+        isCi = System.getenv("CI") == "true"
+    }
     repositories {
         google()
-        maven { url "https://maven-central-asia.storage-download.googleapis.com/repos/central/data/" }
+        if (!isCi) { maven { url "https://maven-central-asia.storage-download.googleapis.com/repos/central/data/" } }
         jcenter()
         maven { url "https://kotlin.bintray.com/kotlinx" }
         maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
@@ -29,7 +32,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        maven { url "https://maven-central-asia.storage-download.googleapis.com/repos/central/data/" }
+        if (!isCi) { maven { url "https://maven-central-asia.storage-download.googleapis.com/repos/central/data/" } }
         jcenter()
         maven { url "https://kotlin.bintray.com/kotlinx" }
         maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
@@ -59,7 +62,7 @@ allprojects {
                 task ktlint(type: JavaExec, group: "verification") {
                     def parameters = ["--android", '--editorconfig', "${rootProject.projectDir}/.editorconfig", "--reporter=checkstyle,output=${buildDir}/ktlint/checkstyle.xml"]
 
-                    if (System.getenv("CI") != "true") {
+                    if (!isCi) {
                         parameters += "--reporter=html,artifact=me.cassiano:ktlint-html-reporter:0.2.0,output=${buildDir}/ktlint/checkstyle.html"
                     }
 

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -41,8 +41,8 @@ android {
     lintOptions {
         lintConfig file("${project.projectDir}/lint.xml")
 
-        xmlReport System.getenv("CI") == "true"
-        htmlReport System.getenv("CI") != "true"
+        xmlReport isCi
+        htmlReport !isCi
 
         xmlOutput file("lint-results.xml")
         htmlOutput file("lint-results.html")

--- a/frontendcomponent/androidcomponent/build.gradle
+++ b/frontendcomponent/androidcomponent/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     androidTestImplementation Dep.Test.espressoCore
 }
 repositories {
-    maven { url "https://maven-central-asia.storage-download.googleapis.com/repos/central/data/" }
+    if (!isCi) { maven { url "https://maven-central-asia.storage-download.googleapis.com/repos/central/data/" } }
     mavenCentral()
 }
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {

--- a/frontendcomponent/androidcomponent/build.gradle
+++ b/frontendcomponent/androidcomponent/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     androidTestImplementation Dep.Test.espressoCore
 }
 repositories {
+    maven { url "https://maven-central-asia.storage-download.googleapis.com/repos/central/data/" }
     mavenCentral()
 }
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {

--- a/frontendcomponent/androidtestcomponent/build.gradle
+++ b/frontendcomponent/androidtestcomponent/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     }
 }
 repositories {
-    maven { url "https://maven-central-asia.storage-download.googleapis.com/repos/central/data/" }
+    if (!isCi) { maven { url "https://maven-central-asia.storage-download.googleapis.com/repos/central/data/" } }
     mavenCentral()
 }
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {

--- a/frontendcomponent/androidtestcomponent/build.gradle
+++ b/frontendcomponent/androidtestcomponent/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     }
 }
 repositories {
+    maven { url "https://maven-central-asia.storage-download.googleapis.com/repos/central/data/" }
     mavenCentral()
 }
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {


### PR DESCRIPTION
## Issue
- close #168

## Overview (Required)
- use Maven Central mirror following to https://storage-download.googleapis.com/maven-central/index.html

## Links
- https://storage-download.googleapis.com/maven-central/index.html

## Screenshot

There is no screenshot but build speed faster than before, I could not measure accurately though.

The following is synchronization time on my MacBook Air. I only measured once.

Before | After
:--: | :--:
synced successfully 10m 29s 199ms | synced successfully 8m 30s 38ms
