### PR TITLE
Fix SessionsItemDecoration not to draw unexpected time text

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
@@ -5,7 +5,10 @@ import android.content.res.Resources
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.util.SparseArray
+import android.view.View
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.util.forEach
 import androidx.recyclerview.widget.RecyclerView
 import com.xwray.groupie.GroupAdapter
 import io.github.droidkaigi.confsched2019.session.R
@@ -42,16 +45,24 @@ class SessionsItemDecoration(
         }
     }
 
+    // Keep SparseArray instance on property to avoid object creation in every onDrawOver()
+    private val positionToViews = SparseArray<View>()
+
     override fun onDrawOver(c: Canvas, parent: RecyclerView, state: RecyclerView.State) {
-        var lastTime: String? = null
+        // Sort child views by adapter position
         for (i in 0 until parent.childCount) {
             val view = parent.getChildAt(i)
             val position = parent.getChildAdapterPosition(view)
-            if (position == -1 || position >= groupAdapter.itemCount) return
+            if (position != -1 && position < groupAdapter.itemCount) {
+                positionToViews.put(position, view)
+            }
+        }
 
-            val time = getSessionTime(position) ?: continue
+        var lastTime: String? = null
+        positionToViews.forEach { position, view ->
+            val time = getSessionTime(position) ?: return@forEach
 
-            if (lastTime == time) continue
+            if (lastTime == time) return@forEach
             lastTime = time
 
             val nextTime = getSessionTime(position + 1)
@@ -68,6 +79,8 @@ class SessionsItemDecoration(
                 paint
             )
         }
+
+        positionToViews.clear()
     }
 
     private fun getSessionTime(position: Int): String? {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
@@ -32,6 +32,8 @@ class SessionsItemDecoration(
     private val textPaddingBottom = resources.getDimensionPixelSize(
         R.dimen.session_bottom_sheet_left_time_text_padding_bottom
     )
+    // Keep SparseArray instance on property to avoid object creation in every onDrawOver()
+    private val adapterPositionToViews = SparseArray<View>()
 
     val paint = Paint().apply {
         style = Paint.Style.FILL
@@ -45,21 +47,18 @@ class SessionsItemDecoration(
         }
     }
 
-    // Keep SparseArray instance on property to avoid object creation in every onDrawOver()
-    private val positionToViews = SparseArray<View>()
-
     override fun onDrawOver(c: Canvas, parent: RecyclerView, state: RecyclerView.State) {
         // Sort child views by adapter position
         for (i in 0 until parent.childCount) {
             val view = parent.getChildAt(i)
             val position = parent.getChildAdapterPosition(view)
-            if (position != -1 && position < groupAdapter.itemCount) {
-                positionToViews.put(position, view)
+            if (position != RecyclerView.NO_POSITION && position < groupAdapter.itemCount) {
+                adapterPositionToViews.put(position, view)
             }
         }
 
         var lastTime: String? = null
-        positionToViews.forEach { position, view ->
+        adapterPositionToViews.forEach { position, view ->
             val time = getSessionTime(position) ?: return@forEach
 
             if (lastTime == time) return@forEach
@@ -80,7 +79,7 @@ class SessionsItemDecoration(
             )
         }
 
-        positionToViews.clear()
+        adapterPositionToViews.clear()
     }
 
     private fun getSessionTime(position: Int): String? {


### PR DESCRIPTION
## Issue
- close #324

## Overview (Required)

### Cause of the issue

- Time texts on session list are drawn by `SessionsItemDecoration`
- `SessionsItemDecoration` processes `RecyclerView`'s children ordered by index

```kotlin
        var lastTime: String? = null
        for (i in 0 until parent.childCount) {
            val view = parent.getChildAt(i)
            val position = parent.getChildAdapterPosition(view)
            if (position == -1 || position >= groupAdapter.itemCount) return

            val time = getSessionTime(position) ?: continue

            if (lastTime == time) continue
            lastTime = time
```

- It skips drawing text if the session time of **previous view** is same
- However, view index order and item position order can be different in RecyclerView
  - i.e. Drawing text should be skipped if the session time of **previous item** (not of previous view) is same
- Although they are luckily matched in most cases, updating item can cause the "unmatched" situation because it adds new View without recycling
  - In that case, `if (lastTime == time)` in above code doesn't work expectedly

### Solution

- Sort `RecyclerView`'s children by item position before processing
  - After this sort, we can assume `lastTime` has the time of previous position items
- Note: We can NOT remove `lastTime` usage by, for example, following code
  - It's because we need to make sure previous position item is in the visible range of `RecyclerView` to skip drawing text
    - If previous item is not visible, the time text has not been drawn. Text drawing shouldn't skip
  - Although following code performs comparison with previous item as expected, it doesn't assure previous item is in `RecyclerView`'s visible range

```kotlin
            val time = getSessionTime(position) ?: continue

            val prevItemTime = getSessionTime(position - 1)
            if (prevItemTime == time) continue
```

## Links
N/A

## Screenshot
Before | After
:--: | :--:
![svid_20190109_223459_1](https://user-images.githubusercontent.com/12084705/50915589-2400ed80-145f-11e9-8cde-340e29a5ac4a.gif) | ![svid_20190109_233031_1](https://user-images.githubusercontent.com/12084705/50919870-02f1ca00-146a-11e9-9ea6-97d2bd759e5b.gif)