### PR TITLE
fix version conflict at clean build

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -115,6 +115,7 @@ object Dep {
         val version = "3.11.0"
         val client = "com.squareup.okhttp3:okhttp:$version"
         val loggingInterceptor = "com.squareup.okhttp3:logging-interceptor:$version"
+        val okio = "com.squareup.okio:okio:1.14.0"
     }
 
     val liveDataKtx = "com.shopify:livedata-ktx:2.0.1"

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -77,6 +77,8 @@ dependencies {
 
     implementation Dep.Kotlin.stdlibJvm
     api Dep.Kotlin.coroutines
+    implementation Dep.Kotlin.androidCoroutinesDispatcher
+    implementation Dep.OkHttp.okio
 
     implementation Dep.Firebase.fireStore
 


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Fixed warning at clean build. Changed to specify version
```
Conflict with dependency 'org.jetbrains.kotlinx:kotlinx-coroutines-android' in project ':frontend:android'. Resolved versions for runtime classpath (1.0.1) and compile classpath (1.0.0) differ. This can lead to runtime crashes. To resolve this issue follow advice at https://developer.android.com/studio/build/gradle-tips#configure-project-wide-properties. Alternatively, you can try to fix the problem by adding this snippet to /Users/wataru/Develop/conference-app-2019/frontend/android/build.gradle:	
Conflict with dependency 'com.squareup.okio:okio' in project ':frontend:android'. Resolved versions for runtime classpath (1.14.0) and compile classpath (1.13.0) differ. This can lead to runtime crashes. To resolve this issue follow advice at https://developer.android.com/studio/build/gradle-tips#configure-project-wide-properties. Alternatively, you can try to fix the problem by adding this snippet to /Users/wataru/Develop/conference-app-2019/frontend/android/build.gradle:
```


## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
