### PR TITLE
Fix time format to 24-hour clock

### DIFF
--- a/model/src/commonMain/kotlin/Session.kt
+++ b/model/src/commonMain/kotlin/Session.kt
@@ -58,9 +58,9 @@ sealed class Session(
             append("日")
         }
         append(" ")
-        append(startTime.format("hh:mm"))
+        append(startTime.format("HH:mm"))
         append(" - ")
-        append(endTime.format("hh:mm"))
+        append(endTime.format("HH:mm"))
     }
 
     fun summary(lang: Lang) = buildString {


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- switch views between a 24-hour clock at session detail page.

## Links
- None.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/885696/50979225-6696f880-1539-11e9-8966-61f981f456cb.png" width="300" /> | <img src="https://user-images.githubusercontent.com/885696/50979263-77476e80-1539-11e9-848a-d3f39618617e.png" width="300" />
- session list page is 24-hour clock, there  is no problem.
<img src="https://user-images.githubusercontent.com/885696/50980288-b676bf00-153b-11e9-995d-69ed0bca3661.png" width="300" >

