### PR TITLE
Add timezone support in timeline

### DIFF
--- a/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/entity/mapper/SessionDataMapperExt.kt
+++ b/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/entity/mapper/SessionDataMapperExt.kt
@@ -40,7 +40,7 @@ private val dateFormat: DateFormat =
 
 private fun parseDateTime(dateText: String): DateTimeTz {
     val tz = "+09:00" // FIXME Should replace to timezone from API
-    return dateFormat.parse("${dateText}${tz}")
+    return dateFormat.parse("$dateText$tz")
 }
 
 fun SessionResponse.toSessionEntityImpl(
@@ -64,7 +64,7 @@ fun SessionResponse.toSessionEntityImpl(
             title = title,
             englishTitle = requireNotNull(englishTitle),
             desc = description,
-            stime = parseDateTime(startsAt ).utc.unixMillisLong,
+            stime = parseDateTime(startsAt).utc.unixMillisLong,
             etime = parseDateTime(endsAt).utc.unixMillisLong,
             sessionFormat = requireNotNull(sessionFormat.name),
             language = LanguageEntityImpl(

--- a/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/entity/mapper/SessionDataMapperExt.kt
+++ b/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/entity/mapper/SessionDataMapperExt.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched2019.data.db.entity.mapper
 
 import com.soywiz.klock.DateFormat
+import com.soywiz.klock.DateTimeTz
 import com.soywiz.klock.parse
 import io.github.droidkaigi.confsched2019.data.api.response.CategoryItemResponse
 import io.github.droidkaigi.confsched2019.data.api.response.CategoryResponse
@@ -35,7 +36,12 @@ fun List<SessionResponse>.toSessionEntities(
     }
 
 private val dateFormat: DateFormat =
-    DateFormat("yyyy-MM-dd'T'HH:mm:ss")
+    DateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
+
+private fun parseDateTime(dateText: String): DateTimeTz {
+    val tz = "+09:00" // FIXME Should replace to timezone from API
+    return dateFormat.parse("${dateText}${tz}")
+}
 
 fun SessionResponse.toSessionEntityImpl(
     categories: List<CategoryResponse>,
@@ -58,8 +64,8 @@ fun SessionResponse.toSessionEntityImpl(
             title = title,
             englishTitle = requireNotNull(englishTitle),
             desc = description,
-            stime = dateFormat.parse(startsAt).utc.unixMillisLong,
-            etime = dateFormat.parse(endsAt).utc.unixMillisLong,
+            stime = parseDateTime(startsAt ).utc.unixMillisLong,
+            etime = parseDateTime(endsAt).utc.unixMillisLong,
             sessionFormat = requireNotNull(sessionFormat.name),
             language = LanguageEntityImpl(
                 requireNotNull(language.id),
@@ -90,8 +96,8 @@ fun SessionResponse.toSessionEntityImpl(
             englishTitle = englishTitle,
             title = title,
             desc = description,
-            stime = dateFormat.parse(startsAt).utc.unixMillisLong,
-            etime = dateFormat.parse(endsAt).utc.unixMillisLong,
+            stime = parseDateTime(startsAt).utc.unixMillisLong,
+            etime = parseDateTime(endsAt).utc.unixMillisLong,
             sessionFormat = null,
             language = null,
             category = null,

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
@@ -107,6 +107,7 @@ class SessionDetailFragment : DaggerFragment() {
     private fun applySessionLayout(session: Session.SpeechSession) {
         binding.session = session
         binding.lang = defaultLang()
+        binding.timeZoneOffsetHours = 9 // FIXME Get from device setting
         @Suppress("StringFormatMatches") // FIXME
         binding.sessionTimeAndRoom.text = getString(
             R.string.session_duration_room_format,

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SpeakerFragment.kt
@@ -49,6 +49,7 @@ class SpeakerFragment : DaggerFragment() {
 
         val speakerId = speakerFragmentArgs.speaker
         binding.lang = defaultLang()
+        binding.timeZoneOffsetHours = 9 // FIXME Get from device setting
         sessionContentsStore.speaker(speakerId).changed(
             this
         ) { speaker ->

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
@@ -7,15 +7,12 @@ import android.graphics.Color
 import android.graphics.Paint
 import androidx.core.content.res.ResourcesCompat
 import androidx.recyclerview.widget.RecyclerView
-import com.soywiz.klock.DateTime
 import com.soywiz.klock.DateTimeSpan
-import com.soywiz.klock.TimeSpan
 import com.xwray.groupie.GroupAdapter
 import io.github.droidkaigi.confsched2019.session.R
 import io.github.droidkaigi.confsched2019.session.ui.item.SessionItem
 import io.github.droidkaigi.confsched2019.timber.debug
 import timber.log.Timber
-import java.util.*
 
 class SessionsItemDecoration(
     val context: Context,

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
@@ -7,11 +7,15 @@ import android.graphics.Color
 import android.graphics.Paint
 import androidx.core.content.res.ResourcesCompat
 import androidx.recyclerview.widget.RecyclerView
+import com.soywiz.klock.DateTime
+import com.soywiz.klock.DateTimeSpan
+import com.soywiz.klock.TimeSpan
 import com.xwray.groupie.GroupAdapter
 import io.github.droidkaigi.confsched2019.session.R
 import io.github.droidkaigi.confsched2019.session.ui.item.SessionItem
 import io.github.droidkaigi.confsched2019.timber.debug
 import timber.log.Timber
+import java.util.*
 
 class SessionsItemDecoration(
     val context: Context,
@@ -71,12 +75,17 @@ class SessionsItemDecoration(
         }
     }
 
+    private val displayTimezoneOffset = lazy {
+        DateTimeSpan(hours = 9) // FIXME Get from device setting
+    }
+
     private fun getSessionTime(position: Int): String? {
         if (position < 0 || position >= groupAdapter.itemCount) {
             return null
         }
 
         val item = groupAdapter.getItem(position) as? SessionItem ?: return null
-        return item.session.startTime.toString("HH:mm")
+        return item.session.startTime
+            .plus(displayTimezoneOffset.value).toString("HH:mm")
     }
 }

--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -26,6 +26,11 @@
             name="lang"
             type="io.github.droidkaigi.confsched2019.model.Lang"
             />
+
+        <variable
+            name="timeZoneOffsetHours"
+            type="Integer"
+            />
     </data>
 
 
@@ -100,7 +105,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
-                    android:text="@{session.timeSummary(lang)}"
+                    android:text="@{session.timeSummary(lang, timeZoneOffsetHours)}"
                     android:textAppearance="@style/TextAppearance.App.Subtitle1"
                     app:layout_constraintBottom_toBottomOf="@id/session_time_image"
                     app:layout_constraintStart_toEndOf="@id/session_time_image"

--- a/feature/session/src/main/res/layout/fragment_speaker.xml
+++ b/feature/session/src/main/res/layout/fragment_speaker.xml
@@ -21,6 +21,11 @@
             name="lang"
             type="io.github.droidkaigi.confsched2019.model.Lang"
             />
+
+        <variable
+                name="timeZoneOffsetHours"
+                type="Integer"
+        />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -173,7 +178,7 @@
                     android:layout_marginEnd="16dp"
                     android:layout_marginTop="4dp"
                     android:paddingBottom="12dp"
-                    android:text="@{session.summary(lang)}"
+                    android:text="@{session.summary(lang, timeZoneOffsetHours)}"
                     android:textAppearance="@style/TextAppearance.App.Caption"
                     app:layout_constraintHorizontal_bias="0"
                     app:layout_constraintStart_toStartOf="@id/speaker_name"

--- a/model/src/commonMain/kotlin/Session.kt
+++ b/model/src/commonMain/kotlin/Session.kt
@@ -1,7 +1,9 @@
 package io.github.droidkaigi.confsched2019.model
 
 import com.soywiz.klock.DateTime
+import com.soywiz.klock.DateTimeSpan
 import com.soywiz.klock.TimeSpan
+import com.soywiz.klock.TimezoneOffset
 
 sealed class Session(
     open val id: String,
@@ -45,7 +47,7 @@ sealed class Session(
 
     val startDayText by lazy { startTime.format("yyyy.M.d") }
 
-    fun timeSummary(lang: Lang) = buildString {
+    fun timeSummary(lang: Lang, timezoneOffsetHours: Int) = buildString {
         // ex: 2月2日 10:20-10:40
         if (lang == Lang.EN) {
             append(startTime.format("M"))
@@ -57,14 +59,15 @@ sealed class Session(
             append(startTime.format("d"))
             append("日")
         }
+        val tzSpan = DateTimeSpan(hours = timezoneOffsetHours)
         append(" ")
-        append(startTime.format("hh:mm"))
+        append(startTime.plus(tzSpan).format("HH:mm"))
         append(" - ")
-        append(endTime.format("hh:mm"))
+        append(endTime.plus(tzSpan).format("HH:mm"))
     }
 
-    fun summary(lang: Lang) = buildString {
-        append(timeSummary(lang))
+    fun summary(lang: Lang, timezoneOffsetHours: Int) = buildString {
+        append(timeSummary(lang, timezoneOffsetHours))
         append(" / ")
         append(timeInMinutes)
         append("min")


### PR DESCRIPTION
## Issue
- #272  

## Overview (Required)
Add timezone support in timeline view.

NOTE:
Currently support only JST(+09:00).
If API returns new timezone field, I will continue to fix.

