### PR TITLE
Fix session list loading error caused because Dispatcher loses action

### DIFF
--- a/frontendcomponent/androidcomponent/build.gradle
+++ b/frontendcomponent/androidcomponent/build.gradle
@@ -8,6 +8,7 @@ apply from: rootProject.file('gradle/android.gradle')
 
 dependencies {
     api project(":model")
+    api project(":ext:android-extension")
     api Dep.AndroidX.design
     api Dep.AndroidX.coreKtx
     implementation Dep.Kotlin.stdlibJvm

--- a/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/dispatcher/Dispatcher.kt
+++ b/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/dispatcher/Dispatcher.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched2019.dispatcher
 
 import io.github.droidkaigi.confsched2019.action.Action
+import io.github.droidkaigi.confsched2019.ext.android.CoroutinePlugin
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.Channel
@@ -8,6 +9,7 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.filter
 import kotlinx.coroutines.channels.map
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -21,11 +23,16 @@ class Dispatcher @Inject constructor() {
     }
 
     suspend fun dispatch(action: Action) {
-        _actions.send(action)
+        // Make sure calling `_actions.send()` from single thread. We can lose action if
+        // `_actions.send()` is called simultaneously from multiple threads
+        // https://github.com/Kotlin/kotlinx.coroutines/blob/1.0.1/common/kotlinx-coroutines-core-common/src/channels/ConflatedBroadcastChannel.kt#L227-L230
+        withContext(CoroutinePlugin.mainDispatcher) {
+            _actions.send(action)
+        }
     }
 
     fun launchAndDispatch(action: Action) {
-        GlobalScope.launch {
+        GlobalScope.launch(CoroutinePlugin.mainDispatcher) {
             _actions.send(action)
         }
     }

--- a/frontendcomponent/androidcomponent/src/test/java/io/github/droidkaigi/confsched2019/dispatcher/DispatcherTest.kt
+++ b/frontendcomponent/androidcomponent/src/test/java/io/github/droidkaigi/confsched2019/dispatcher/DispatcherTest.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched2019.dispatcher
 
 import io.github.droidkaigi.confsched2019.action.Action
+import io.github.droidkaigi.confsched2019.ext.android.CoroutinePlugin
 import io.github.droidkaigi.confsched2019.model.SessionContents
 import io.mockk.mockk
 import kotlinx.coroutines.async
@@ -8,13 +9,20 @@ import kotlinx.coroutines.channels.map
 import kotlinx.coroutines.channels.take
 import kotlinx.coroutines.channels.toList
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers.hasItems
 import org.hamcrest.core.Is.`is`
 import org.junit.Assert.assertThat
+import org.junit.Before
 import org.junit.Test
 
 class DispatcherTest {
+    @Before fun setUp() {
+        val pseudoMainDispatcher = newSingleThreadContext("DispatcherTest")
+        CoroutinePlugin.mainDispatcherHandler = { pseudoMainDispatcher }
+    }
+
     @Test fun sendAndReceive() {
         val sessionContents: SessionContents = mockk()
         val dispatcher = Dispatcher()


### PR DESCRIPTION
## Issue
- close #157

## Overview (Required)

### Cause of the issue

- `Action.UserRegistered` dispatched from `UserActionCreator` was randomly lost in race condition
  - If `Action.UserRegistered` is lost, `UserStore.registered` doesn't become `true` and `SessionContentsActionCreator.refresh()` never be triggered from `SessionPagesFragment`
  - It make session pages keep empty
- The loss is caused because of the implementation of `Dispatcher.launchAndDispatch()`:

```kotlin
class Dispatcher @Inject constructor() {
    private val _actions = BroadcastChannel<Action>(Channel.CONFLATED)
    // ...

    fun launchAndDispatch(action: Action) {
        GlobalScope.launch {
            _actions.send(action)
        }
    }
```

- The actual class of `_actions` is [`ConflatedBroadcastChannel`](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.channels/-conflated-broadcast-channel/)
- `launchAndDispatch()` uses `GlobalScope` to start coroutine. It means the coroutine runs in [default dispatcher](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-dispatchers/-default.html), which is a thread pool on JVM
- If `launchAndDispatch()` is called multiple times in a short time, `ConflatedBroadcastChannel.send()` can be simultaneously executed in multiple thread
  - In such case, the 2nd and following calls are ignored by `ConflatedBroadcastChannel` because the channel doesn't have buffer. See  https://github.com/Kotlin/kotlinx.coroutines/blob/1.0.1/common/kotlinx-coroutines-core-common/src/channels/ConflatedBroadcastChannel.kt#L227-L230
- `Action.UserRegistered` is sometimes dispatched just after `Action.SessionsLoaded` when launching app
  - It causes loss of `Action.UserRegistered`

### Solution

- Make sure that `ConflatedBroadcastChannel.send()` is called in main thread not to lose any action

## Links
N/A

## Screenshot
Before | After
:--: | :--:
![svid_20190111_021847_1](https://user-images.githubusercontent.com/12084705/50996427-e2983d00-1547-11e9-8ee5-7fb70eb1fad8.gif) | ![svid_20190111_021643_1](https://user-images.githubusercontent.com/12084705/50996426-e2983d00-1547-11e9-82e1-29805e89c00e.gif)