### PR TITLE
Fix binding name collision warning

### DIFF
--- a/feature/sponsor/src/main/res/layout/item_header.xml
+++ b/feature/sponsor/src/main/res/layout/item_header.xml
@@ -17,7 +17,7 @@
         xmlns:app="http://schemas.android.com/apk/res-auto">
 
         <TextView
-            android:id="@+id/title"
+            android:id="@+id/title_view"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:fontFamily="@font/lekton"


### PR DESCRIPTION
## Overview (Required)
- Compiler warns that binding variable `title` collides with view id `title`.
```
w: warning: View field title collides with a variable or import
  file:///home/circleci/conference-app-2019/feature/sponsor/src/main/res/layout/item_header.xml Line:18
```
Years ago, it was generating wrong code. 
