### PR TITLE
Remove redundant namespace on BindingAdapter

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/ImageViewBinding.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/ImageViewBinding.kt
@@ -8,7 +8,7 @@ import com.squareup.picasso.Picasso
 import jp.wasabeef.picasso.transformations.CropCircleTransformation
 
 // waiting https://stackoverflow.com/questions/53975575/databinding-bindingadapter-in-library-project-is-not-applied
-@BindingAdapter(value = ["app:imageUrl"])
+@BindingAdapter(value = ["imageUrl"])
 fun loadImage(imageView: ImageView, imageUrl: String?) {
     loadImage(
         imageView = imageView,
@@ -21,10 +21,10 @@ fun loadImage(imageView: ImageView, imageUrl: String?) {
 
 @BindingAdapter(
     value = [
-        "app:imageUrl",
-        "app:circleCrop",
-        "app:placeHolder",
-        "app:placeHolderTint"
+        "imageUrl",
+        "circleCrop",
+        "placeHolder",
+        "placeHolderTint"
     ]
 )
 fun loadImage(

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/ViewBinding.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/ViewBinding.kt
@@ -3,7 +3,7 @@ package io.github.droidkaigi.confsched2019.session.ui.bindingadapter
 import android.view.View
 import androidx.databinding.BindingAdapter
 
-@BindingAdapter(value = ["app:visibleGone"])
+@BindingAdapter(value = ["visibleGone"])
 fun showHide(view: View, show: Boolean) {
     view.visibility = if (show) View.VISIBLE else View.GONE
 }


### PR DESCRIPTION
## Overview (Required)
- DataBinding ignores namespace (except for `android`) on `@BindingAdapter`. It have nothing to affect.
```
w: /home/circleci/conference-app-2019/feature/session/build/tmp/kapt3/stubs/debug/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/ViewBindingKt.java:9: warning: Application namespace for attribute app:visibleGone will be ignored.
    public static final void showHide(@org.jetbrains.annotations.NotNull()
                             ^
w: /home/circleci/conference-app-2019/feature/session/build/tmp/kapt3/stubs/debug/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/ImageViewBindingKt.java:9: warning: Application namespace for attribute app:imageUrl will be ignored.
    public static final void loadImage(@org.jetbrains.annotations.NotNull()
                             ^
w: /home/circleci/conference-app-2019/feature/session/build/tmp/kapt3/stubs/debug/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/ImageViewBindingKt.java:15: warning: Application namespace for attribute app:imageUrl will be ignored.
    public static final void loadImage(@org.jetbrains.annotations.NotNull()
                             ^
w: /home/circleci/conference-app-2019/feature/session/build/tmp/kapt3/stubs/debug/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/ImageViewBindingKt.java:15: warning: Application namespace for attribute app:circleCrop will be ignored.
    public static final void loadImage(@org.jetbrains.annotations.NotNull()
                             ^
w: /home/circleci/conference-app-2019/feature/session/build/tmp/kapt3/stubs/debug/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/ImageViewBindingKt.java:15: warning: Application namespace for attribute app:placeHolder will be ignored.
    public static final void loadImage(@org.jetbrains.annotations.NotNull()
                             ^
w: /home/circleci/conference-app-2019/feature/session/build/tmp/kapt3/stubs/debug/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/ImageViewBindingKt.java:15: warning: Application namespace for attribute app:placeHolderTint will be ignored.
    public static final void loadImage(@org.jetbrains.annotations.NotNull()
```
