### PR TITLE
Change the primary key of Sponsor: name -> id

### DIFF
--- a/data/api-impl/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/response/SponsorItemResponseImpl.kt
+++ b/data/api-impl/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/response/SponsorItemResponseImpl.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class SponsorItemResponseImpl(
+    override val id: Int,
     override val name: String,
     override val url: String,
     override val image: String

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/response/SponsorItemResponse.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/response/SponsorItemResponse.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched2019.data.api.response
 
 interface SponsorItemResponse {
+    val id: Int
     val name: String
     val url: String
     val image: String

--- a/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/CacheDatabase.kt
+++ b/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/CacheDatabase.kt
@@ -22,7 +22,7 @@ import io.github.droidkaigi.confsched2019.data.db.entity.SponsorEntityImpl
         (SponsorEntityImpl::class),
         (SessionFeedbackImpl::class)
     ],
-    version = 9
+    version = 10
 )
 abstract class CacheDatabase : RoomDatabase() {
     abstract fun sessionDao(): SessionDao

--- a/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/dao/SponsorDao.kt
+++ b/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/dao/SponsorDao.kt
@@ -8,7 +8,7 @@ import io.github.droidkaigi.confsched2019.data.db.entity.SponsorEntityImpl
 
 @Dao
 abstract class SponsorDao {
-    @Query("SELECT * FROM sponsor")
+    @Query("SELECT * FROM sponsor ORDER BY categoryIndex, displayOrder ASC")
     abstract suspend fun allSponsors(): List<SponsorEntityImpl>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/entity/SponsorEntityImpl.kt
+++ b/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/entity/SponsorEntityImpl.kt
@@ -6,9 +6,11 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "sponsor")
 data class SponsorEntityImpl(
     @PrimaryKey
+    override var id: Int,
     override var name: String,
     override var url: String,
     override var image: String,
     override var category: String,
-    override var categoryIndex: Int
+    override var categoryIndex: Int,
+    override var displayOrder: Int
 ) : SponsorEntity

--- a/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/entity/mapper/SponsorDataMapperExt.kt
+++ b/data/db-room/src/main/java/io/github/droidkaigi/confsched2019/data/db/entity/mapper/SponsorDataMapperExt.kt
@@ -7,12 +7,14 @@ fun List<SponsorItemResponse>.toSponsorEntities(
     category: String,
     categoryIndex: Int
 ): List<SponsorEntityImpl> =
-    map { responseSponsor ->
+    mapIndexed { displayOrder, responseSponsor ->
         SponsorEntityImpl(
+            responseSponsor.id,
             responseSponsor.name,
             responseSponsor.url,
             responseSponsor.image,
             category,
-            categoryIndex
+            categoryIndex,
+            displayOrder
         )
     }

--- a/data/db/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/db/entity/SponsorEntity.kt
+++ b/data/db/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/db/entity/SponsorEntity.kt
@@ -1,9 +1,11 @@
 package io.github.droidkaigi.confsched2019.data.db.entity
 
 interface SponsorEntity {
+    var id: Int
     var name: String
     var url: String
     var image: String
     var category: String
     var categoryIndex: Int
+    var displayOrder: Int
 }


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- SponsorEntityImpl uses `name` column as primary key, But  [Sponsor API Response](https://droidkaigi2019-dev.appspot.com/api/sponsors) includes duplicate name entries.

⬇️ like this
```json
{"id":"19","url":"https://mixi.co.jp/recruit/","kind":"gold","name":"株式会社ミクシィ","image":"https://storage.googleapis.com/droidkaigi-sponsor-image-dev/sponsor/2019/19.png"},
{"id":"20","url":"https://career.xflag.com/","kind":"gold","name":"株式会社ミクシィ","image":"https://storage.googleapis.com/droidkaigi-sponsor-image-dev/sponsor/2019/20.png"},
```

Since `id=19` will be overwritten by `id=20`, `株式会社ミクシィ(id=19)` has disappeared from SponsorFragment 😢 

- Add `displayOrder` column into Sponsor to make the display order same as the API response.

## Links
- Sponsor API Response https://droidkaigi2019-dev.appspot.com/api/sponsors
- Official Sponsor List https://droidkaigi.jp/2019/

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3610682/51021674-8ffd6600-15c5-11e9-8392-02541b170136.png" width="300" /> | <img src="https://user-images.githubusercontent.com/3610682/51021687-9be92800-15c5-11e9-9735-1e2cc12973ed.png" width="300" />