### PR TITLE
Draw line between time labels

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
@@ -111,7 +111,10 @@ class SessionsItemDecoration(
             if (nextTimePosition < 0) return@forEach
 
             val offset = if (timeText.fixed) -view.top.toFloat() else 0F
-            dashLinePaint.pathEffect = DashPathEffect(floatArrayOf(lineInterval, lineInterval), offset)
+            dashLinePaint.pathEffect = DashPathEffect(
+                floatArrayOf(lineInterval, lineInterval),
+                offset
+            )
 
             // draw line to next time text if exists, otherwise draw line to the bottom
             calcTimeText(parent, nextTimePosition)?.let { nextTimeText ->

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
@@ -36,12 +36,16 @@ class SessionsItemDecoration(
     private val textPaddingBottom = resources.getDimensionPixelSize(
         R.dimen.session_bottom_sheet_left_time_text_padding_bottom
     )
+    private val lineInterval = resources.getDimensionPixelSize(
+        R.dimen.session_bottom_sheet_left_time_line_interval
+    ).toFloat()
     // Keep SparseArray instance on property to avoid object creation in every onDrawOver()
     private val adapterPositionToViews = SparseArray<View>()
 
     private data class TimeText(
         val text: String,
-        val y: Float
+        val y: Float,
+        val fixed: Boolean
     )
 
     private val paint = Paint().apply {
@@ -62,7 +66,6 @@ class SessionsItemDecoration(
         strokeWidth = resources.getDimensionPixelSize(
             R.dimen.session_bottom_sheet_left_time_line_width
         ).toFloat()
-        pathEffect = DashPathEffect(floatArrayOf(10F, 10F), 0F)
         isAntiAlias = true
     }
 
@@ -107,6 +110,9 @@ class SessionsItemDecoration(
             // no more different time sessions below, no need to draw line
             if (nextTimePosition < 0) return@forEach
 
+            val offset = if (timeText.fixed) -view.top.toFloat() else 0F
+            dashLinePaint.pathEffect = DashPathEffect(floatArrayOf(lineInterval, lineInterval), offset)
+
             // draw line to next time text if exists, otherwise draw line to the bottom
             calcTimeText(parent, nextTimePosition)?.let { nextTimeText ->
                 c.drawLine(
@@ -142,7 +148,8 @@ class SessionsItemDecoration(
         if (time != nextTime) {
             y = y.coerceAtMost(view.bottom - textPaddingBottom)
         }
-        return TimeText(time, y.toFloat())
+        val fixed = y == textPaddingTop + textSize
+        return TimeText(time, y.toFloat(), fixed)
     }
 
     private fun calcTimeText(parent: RecyclerView, position: Int): TimeText? {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.Resources
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.DashPathEffect
 import android.graphics.Paint
 import android.util.SparseArray
 import android.view.View
@@ -37,7 +38,12 @@ class SessionsItemDecoration(
     // Keep SparseArray instance on property to avoid object creation in every onDrawOver()
     private val adapterPositionToViews = SparseArray<View>()
 
-    val paint = Paint().apply {
+    private data class TimeText(
+        val text: String,
+        val y: Float
+    )
+
+    private val paint = Paint().apply {
         style = Paint.Style.FILL
         textSize = this@SessionsItemDecoration.textSize.toFloat()
         color = Color.BLACK
@@ -49,6 +55,17 @@ class SessionsItemDecoration(
         }
     }
 
+    private val dashLinePaint = Paint().apply {
+        style = Paint.Style.STROKE
+        color = 0xff888888.toInt()
+        pathEffect = DashPathEffect(floatArrayOf(10F, 10F), 0F)
+        isAntiAlias = true
+    }
+
+    private val fontMetrics = paint.fontMetrics
+    private val textX = textLeftSpace.toFloat()
+    private val lineX = textX + (paint.measureText("00:00") / 2F)
+
     override fun onDrawOver(c: Canvas, parent: RecyclerView, state: RecyclerView.State) {
         // Sort child views by adapter position
         for (i in 0 until parent.childCount) {
@@ -59,26 +76,51 @@ class SessionsItemDecoration(
             }
         }
 
-        var lastTime: String? = null
+        var lastTimeText: TimeText? = null
         adapterPositionToViews.forEach { position, view ->
-            val time = getSessionTime(position) ?: return@forEach
+            val timeText = calcTimeText(position, view) ?: return@forEach
 
-            if (lastTime == time) return@forEach
-            lastTime = time
-
-            val nextTime = getSessionTime(position + 1)
-
-            var textY = view.top.coerceAtLeast(0) + textPaddingTop + textSize
-            if (time != nextTime) {
-                textY = textY.coerceAtMost(view.bottom - textPaddingBottom)
-            }
+            if (timeText.text == lastTimeText?.text) return@forEach
+            lastTimeText = timeText
 
             c.drawText(
-                time,
-                textLeftSpace.toFloat(),
-                textY.toFloat(),
+                timeText.text,
+                textX,
+                timeText.y,
                 paint
             )
+
+            // find next time session from all sessions
+            var nextTimePosition = -1
+            for (pos in position until groupAdapter.itemCount) {
+                val time = getSessionTime(pos)
+                if (time != timeText.text) {
+                    nextTimePosition = pos
+                    break
+                }
+            }
+
+            // no more different time sessions below, no need to draw line
+            if (nextTimePosition < 0) return@forEach
+
+            // draw line to next time text if exists, otherwise draw line to the bottom
+            calcTimeText(parent, nextTimePosition)?.let { nextTimeText ->
+                c.drawLine(
+                    lineX,
+                    timeText.y + fontMetrics.bottom,
+                    lineX,
+                    nextTimeText.y + fontMetrics.top,
+                    dashLinePaint
+                )
+            } ?: run {
+                c.drawLine(
+                    lineX,
+                    timeText.y + fontMetrics.bottom,
+                    lineX,
+                    c.height.toFloat(),
+                    dashLinePaint
+                )
+            }
         }
 
         adapterPositionToViews.clear()
@@ -87,6 +129,24 @@ class SessionsItemDecoration(
     private val displayTimezoneOffset = lazy {
         DateTimeSpan(hours = 9) // FIXME Get from device setting
     }
+
+    private fun calcTimeText(position: Int, view: View): TimeText? {
+        val time = getSessionTime(position) ?: return null
+        val nextTime = getSessionTime(position + 1)
+
+        var y = view.top.coerceAtLeast(0) + textPaddingTop + textSize
+        if (time != nextTime) {
+            y = y.coerceAtMost(view.bottom - textPaddingBottom)
+        }
+        return TimeText(time, y.toFloat())
+    }
+
+    private fun calcTimeText(parent: RecyclerView, position: Int): TimeText? {
+        val view = parent.findViewHolderForAdapterPosition(position)?.itemView
+            ?: return null
+        return calcTimeText(position, view)
+    }
+
 
     private fun getSessionTime(position: Int): String? {
         if (position < 0 || position >= groupAdapter.itemCount) {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
@@ -8,6 +8,7 @@ import android.graphics.DashPathEffect
 import android.graphics.Paint
 import android.util.SparseArray
 import android.view.View
+import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.util.forEach
 import androidx.recyclerview.widget.RecyclerView
@@ -57,7 +58,8 @@ class SessionsItemDecoration(
 
     private val dashLinePaint = Paint().apply {
         style = Paint.Style.STROKE
-        color = 0xff888888.toInt()
+        color = ContextCompat.getColor(context, R.color.gray3)
+        strokeWidth = resources.getDimensionPixelSize(R.dimen.session_bottom_sheet_left_time_line_width).toFloat()
         pathEffect = DashPathEffect(floatArrayOf(10F, 10F), 0F)
         isAntiAlias = true
     }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
@@ -59,7 +59,9 @@ class SessionsItemDecoration(
     private val dashLinePaint = Paint().apply {
         style = Paint.Style.STROKE
         color = ContextCompat.getColor(context, R.color.gray3)
-        strokeWidth = resources.getDimensionPixelSize(R.dimen.session_bottom_sheet_left_time_line_width).toFloat()
+        strokeWidth = resources.getDimensionPixelSize(
+            R.dimen.session_bottom_sheet_left_time_line_width
+        ).toFloat()
         pathEffect = DashPathEffect(floatArrayOf(10F, 10F), 0F)
         isAntiAlias = true
     }
@@ -148,7 +150,6 @@ class SessionsItemDecoration(
             ?: return null
         return calcTimeText(position, view)
     }
-
 
     private fun getSessionTime(position: Int): String? {
         if (position < 0 || position >= groupAdapter.itemCount) {

--- a/feature/session/src/main/res/values/dimens.xml
+++ b/feature/session/src/main/res/values/dimens.xml
@@ -6,6 +6,7 @@
     <dimen name="session_bottom_sheet_left_time_text_padding_top">0dp</dimen>
     <dimen name="session_bottom_sheet_left_time_text_padding_bottom">8dp</dimen>
     <dimen name="session_bottom_sheet_left_time_line_width">1dp</dimen>
+    <dimen name="session_bottom_sheet_left_time_line_interval">4dp</dimen>
     <dimen name="session_bottom_sheet_filter_icon_padding">8dp</dimen>
     <dimen name="session_bottom_sheet_filter_text_padding">0dp</dimen>
     <dimen name="session_item_top_padding">4dp</dimen>

--- a/feature/session/src/main/res/values/dimens.xml
+++ b/feature/session/src/main/res/values/dimens.xml
@@ -5,6 +5,7 @@
     <dimen name="session_bottom_sheet_left_time_text_left">16dp</dimen>
     <dimen name="session_bottom_sheet_left_time_text_padding_top">0dp</dimen>
     <dimen name="session_bottom_sheet_left_time_text_padding_bottom">8dp</dimen>
+    <dimen name="session_bottom_sheet_left_time_line_width">1dp</dimen>
     <dimen name="session_bottom_sheet_filter_icon_padding">8dp</dimen>
     <dimen name="session_bottom_sheet_filter_text_padding">0dp</dimen>
     <dimen name="session_item_top_padding">4dp</dimen>


### PR DESCRIPTION
## Issue
- close #319

## Overview (Required)
- Change `SessionItemDecoration` to draw lines between time labels.
- No lines will be drawn below the last session.

## Links
- https://gallery.io/projects/MCHbtQVoQ2HCZd9Pbpex4PVP/files/MCHtA7U1iMGr6907YDmqSpaup_woDHhdXis

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/21209469/51047348-96aecc00-160b-11e9-8f70-2939095ab505.png" width="300" /> | <img src="https://user-images.githubusercontent.com/21209469/51068898-63e6f100-1668-11e9-9fd7-1b84cc72048c.png" width="300" />
<img src="https://user-images.githubusercontent.com/21209469/51047357-9ca4ad00-160b-11e9-9fd7-e35c48e22a46.png" width="300" /> | <img src="https://user-images.githubusercontent.com/21209469/51068899-63e6f100-1668-11e9-91e6-6c519e81ddf0.png" width="300" />
