### PR TITLE
Change navigation drawer toggle icon

### DIFF
--- a/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/MainActivity.kt
+++ b/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/MainActivity.kt
@@ -88,8 +88,9 @@ class MainActivity : DaggerAppCompatActivity() {
     }
 
     private fun setupNavigation() {
+        val topLevelDestinationIds = setOf(R.id.main, R.id.about, R.id.announce, R.id.setting)
         val appBarConfiguration = AppBarConfiguration(
-            setOf(R.id.main, R.id.about, R.id.announce, R.id.setting),
+            topLevelDestinationIds,
             binding.drawerLayout
         )
         setupActionBarWithNavController(navController, appBarConfiguration)
@@ -107,6 +108,11 @@ class MainActivity : DaggerAppCompatActivity() {
                 } else {
                     0
                 }
+            }
+            if (destination.id in topLevelDestinationIds) {
+                binding.toolbar.setNavigationIcon(R.drawable.ic_hamburger)
+            } else {
+                binding.toolbar.setNavigationIcon(R.drawable.ic_back_arrow)
             }
             val toolbarContentsColor = ContextCompat.getColor(
                 this, if (config.isWhiteTheme) android.R.color.black else R.color.white

--- a/frontend/android/src/main/res/drawable/ic_back_arrow.xml
+++ b/frontend/android/src/main/res/drawable/ic_back_arrow.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:bottom="14dp"
+        android:drawable="@drawable/abc_ic_ab_back_material"
+        android:left="14dp"
+        android:right="14dp"
+        android:top="14dp"
+        />
+</layer-list>

--- a/frontend/android/src/main/res/drawable/ic_hamburger.xml
+++ b/frontend/android/src/main/res/drawable/ic_hamburger.xml
@@ -1,0 +1,29 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="56dp"
+    android:viewportHeight="56"
+    android:viewportWidth="40"
+    >
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillType="nonZero"
+        android:pathData="M0,27h24v2h-24z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1"
+        />
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillType="nonZero"
+        android:pathData="M0,35h24v2h-24z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1"
+        />
+    <path
+        android:fillColor="#FFFFFF"
+        android:fillType="nonZero"
+        android:pathData="M0,19h24v2h-24z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1"
+        />
+</vector>

--- a/frontend/android/src/main/res/layout/activity_main.xml
+++ b/frontend/android/src/main/res/layout/activity_main.xml
@@ -36,18 +36,19 @@
                 android:layout_height="wrap_content"
                 android:background="@{isWhiteTheme ? Converters.convertColorToDrawable(@color/white) : Converters.convertColorToDrawable(@color/colorPrimary)}"
                 android:elevation="0dp"
+                android:theme="@style/Widget.App.Toolbar"
+                app:contentInsetStartWithNavigation="0dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                app:contentInsetStartWithNavigation="0dp"
                 >
 
                 <ImageView
                     android:id="@+id/logo"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    app:srcCompat="@drawable/bg_logo"
                     android:contentDescription="@string/app_logo_description"
+                    app:srcCompat="@drawable/bg_logo"
                     />
             </androidx.appcompat.widget.Toolbar>
 

--- a/frontend/android/src/main/res/values/styles.xml
+++ b/frontend/android/src/main/res/values/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Widget.App.Toolbar" parent="ThemeOverlay.AppCompat.ActionBar">
+        <item name="toolbarNavigationButtonStyle">@style/Widget.App.Toolbar.Button.Navigation</item>
+    </style>
+
+    <style name="Widget.App.Toolbar.Button.Navigation" parent="Widget.AppCompat.Toolbar.Button.Navigation">
+        <item name="android:minWidth">40dp</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Issue
- close #97

## Overview (Required)
- Apply hamburger icon design
  - I change manually the navigation icon in order to whether the screen is top level.
- Unfortunately, this PR disable the navigation icon animation. So, if it is not acceptable, please close this PR.

## Screenshot
| |Before | After
:--:|:--: | :--:
main|![before_main](https://user-images.githubusercontent.com/7804631/51071164-f8b11500-168f-11e9-9a57-e89c85929673.png)|![after_main](https://user-images.githubusercontent.com/7804631/51071165-ff3f8c80-168f-11e9-8f16-6e94a25dc3d1.png)|
up icon|![before_up](https://user-images.githubusercontent.com/7804631/51071170-167e7a00-1690-11e9-8199-b6e4a5d3e089.png)|![after_up](https://user-images.githubusercontent.com/7804631/51071172-1b432e00-1690-11e9-9b28-2d1b0e1e4026.png)
white theme|![before_white](https://user-images.githubusercontent.com/7804631/51071179-27c78680-1690-11e9-9fb4-451bd0c40831.png)|![after_white](https://user-images.githubusercontent.com/7804631/51071182-2bf3a400-1690-11e9-8de0-e04d1bf945ba.png)|


