### PR TITLE
fixed multiple starts of sponsor page.

### DIFF
--- a/feature/system/src/main/java/io/github/droidkaigi/confsched2019/system/actioncreator/ActivityActionCreator.kt
+++ b/feature/system/src/main/java/io/github/droidkaigi/confsched2019/system/actioncreator/ActivityActionCreator.kt
@@ -16,7 +16,7 @@ class ActivityActionCreator @Inject constructor(val activity: FragmentActivity) 
             .enableUrlBarHiding()
             .setToolbarColor(ContextCompat.getColor(activity, R.color.white))
             .build()
-        customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         customTabsIntent.launchUrl(activity, Uri.parse(url))
     }
 

--- a/feature/system/src/main/java/io/github/droidkaigi/confsched2019/system/actioncreator/ActivityActionCreator.kt
+++ b/feature/system/src/main/java/io/github/droidkaigi/confsched2019/system/actioncreator/ActivityActionCreator.kt
@@ -16,6 +16,7 @@ class ActivityActionCreator @Inject constructor(val activity: FragmentActivity) 
             .enableUrlBarHiding()
             .setToolbarColor(ContextCompat.getColor(activity, R.color.white))
             .build()
+        customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         customTabsIntent.launchUrl(activity, Uri.parse(url))
     }
 

--- a/feature/system/src/main/java/io/github/droidkaigi/confsched2019/system/actioncreator/ActivityActionCreator.kt
+++ b/feature/system/src/main/java/io/github/droidkaigi/confsched2019/system/actioncreator/ActivityActionCreator.kt
@@ -16,7 +16,11 @@ class ActivityActionCreator @Inject constructor(val activity: FragmentActivity) 
             .enableUrlBarHiding()
             .setToolbarColor(ContextCompat.getColor(activity, R.color.white))
             .build()
+
+        // block to multiple launch a Activity
         customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+
+        // launch a Custom Tabs Activity
         customTabsIntent.launchUrl(activity, Uri.parse(url))
     }
 


### PR DESCRIPTION
## Issue
- None.

## Overview (Required)
- Multiple starts of sponsor page by continuous tap.
- Other pages (Twitter, Github) The URL display function is the same.

## Links
- None.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/885696/51071363-192e9e80-1693-11e9-81e0-39a9e722b2b3.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/885696/51071369-29df1480-1693-11e9-8395-d39e35e7e36d.gif" width="300" />
