### PR TITLE
Change ripple shape of session tab item

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionPagesFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionPagesFragment.kt
@@ -6,6 +6,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
@@ -109,6 +110,19 @@ class SessionPagesFragment : DaggerFragment() {
                 }
             }
         )
+
+        (0 until binding.sessionsTabLayout.tabCount).forEach { tabIndex ->
+            val tab = binding.sessionsTabLayout.getTabAt(tabIndex)
+            tab?.let {
+                val view = layoutInflater.inflate(
+                    R.layout.layout_tab_item, binding.sessionsTabLayout, false
+                ) as? TextView
+                view?.let { textView ->
+                    textView.text = tab.text
+                    it.customView = textView
+                }
+            }
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/feature/session/src/main/res/drawable/shape_pill_background.xml
+++ b/feature/session/src/main/res/drawable/shape_pill_background.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@android:color/white">
+    <item
+        android:id="@android:id/mask"
+        android:bottom="4dp"
+        android:left="12dp"
+        android:right="12dp"
+        android:top="4dp"
+        >
+        <shape
+            android:shape="rectangle">
+            <solid android:color="@android:color/black"/>
+            <corners android:radius="50dp"/>
+        </shape>
+    </item>
+</ripple>

--- a/feature/session/src/main/res/layout/fragment_session_pages.xml
+++ b/feature/session/src/main/res/layout/fragment_session_pages.xml
@@ -23,9 +23,8 @@
             app:layout_constraintTop_toTopOf="parent"
             app:tabGravity="fill"
             app:tabIndicator="@drawable/shape_pill_indicator"
+            app:tabRippleColor="@null"
             app:tabIndicatorGravity="stretch"
-            app:tabTextAppearance="@style/TabTextAppearance"
-            app:tabTextColor="@color/white"
             />
 
         <androidx.viewpager.widget.ViewPager

--- a/feature/session/src/main/res/layout/layout_tab_item.xml
+++ b/feature/session/src/main/res/layout/layout_tab_item.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:textAppearance="@style/TabTextAppearance"
+    android:gravity="center"
+    android:background="@drawable/shape_pill_background"
+    />

--- a/feature/session/src/main/res/values/styles.xml
+++ b/feature/session/src/main/res/values/styles.xml
@@ -9,5 +9,7 @@
         <item name="android:fontFamily">@font/notosans_medium</item>
         <item name="fontFamily">@font/notosans_medium</item>
         <item name="android:textSize">12sp</item>
+        <item name="android:textColor">@color/white</item>
+        <item name="android:textAlignment">center</item>
     </style>
 </resources>


### PR DESCRIPTION
## Issue
- close #393 

## Overview (Required)
We can set background of tab item with app:tabBackground.
But it is not set to `background` of TabView.
It's just used to background rendering on onDraw of TabView.
So we cannot set ripple shape with it.
I set CustomView of Tab to do it.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1386930/51070114-f09ca980-167e-11e9-85b5-e3616d91b12b.png" width="300" /> | <img src="https://user-images.githubusercontent.com/10704349/51071554-21d4a400-1696-11e9-8b9d-9bd37dea02cb.png" width="300" />
... | GIF Anim <img src="https://user-images.githubusercontent.com/10704349/51071612-41200100-1697-11e9-939b-b26c0acf8b1f.gif" width="300" />



