### PR TITLE
delete unneeded listener field

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
@@ -50,26 +50,24 @@ class SpeechSessionItem @AssistedInject constructor(
         ): SpeechSessionItem
     }
 
-    private val onFavoriteClickListener: () -> Unit = {
-        sessionContentsActionCreator.toggleFavorite(session)
-    }
-    private val onClickListener: () -> Unit = {
-        navController
-            .navigate(
-                navDirections
-            )
-    }
     val layoutInflater by lazyWithParam<Context, LayoutInflater> { context ->
         LayoutInflater.from(context)
     }
 
     override fun bind(viewBinding: ItemSessionBinding, position: Int) {
         with(viewBinding) {
-            root.setOnClickListener { onClickListener() }
+            root.setOnClickListener {
+                navController
+                    .navigate(
+                        navDirections
+                    )
+            }
             session = speechSession
             lang = defaultLang()
             addPaddingForTime = this@SpeechSessionItem.addPaddingForTime
-            favorite.setOnClickListener { onFavoriteClickListener() }
+            favorite.setOnClickListener {
+                sessionContentsActionCreator.toggleFavorite(speechSession)
+            }
             @Suppress("StringFormatMatches") // FIXME
             timeAndRoom.text = root.context.getString(
                 R.string.session_duration_room_format,

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
@@ -50,10 +50,10 @@ class SpeechSessionItem @AssistedInject constructor(
         ): SpeechSessionItem
     }
 
-    private val onFavoriteClickListener: (Session.SpeechSession) -> Unit = { session ->
+    private val onFavoriteClickListener: () -> Unit = {
         sessionContentsActionCreator.toggleFavorite(session)
     }
-    private val onClickListener: (Session.SpeechSession) -> Unit = { session ->
+    private val onClickListener: () -> Unit = {
         navController
             .navigate(
                 navDirections
@@ -65,13 +65,11 @@ class SpeechSessionItem @AssistedInject constructor(
 
     override fun bind(viewBinding: ItemSessionBinding, position: Int) {
         with(viewBinding) {
-            root.setOnClickListener { onClickListener(speechSession) }
+            root.setOnClickListener { onClickListener() }
             session = speechSession
             lang = defaultLang()
             addPaddingForTime = this@SpeechSessionItem.addPaddingForTime
-            favorite.setOnClickListener {
-                onFavoriteClickListener(speechSession)
-            }
+            favorite.setOnClickListener { onFavoriteClickListener() }
             @Suppress("StringFormatMatches") // FIXME
             timeAndRoom.text = root.context.getString(
                 R.string.session_duration_room_format,

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
@@ -57,10 +57,7 @@ class SpeechSessionItem @AssistedInject constructor(
     override fun bind(viewBinding: ItemSessionBinding, position: Int) {
         with(viewBinding) {
             root.setOnClickListener {
-                navController
-                    .navigate(
-                        navDirections
-                    )
+                navController.navigate(navDirections)
             }
             session = speechSession
             lang = defaultLang()

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
@@ -33,8 +33,8 @@ class SpeechSessionItem @AssistedInject constructor(
     @Assisted override val session: Session.SpeechSession,
     @Assisted val navDirections: NavDirections,
     @Assisted val addPaddingForTime: Boolean,
-    navController: NavController,
-    sessionContentsActionCreator: SessionContentsActionCreator,
+    val navController: NavController,
+    val sessionContentsActionCreator: SessionContentsActionCreator,
     val systemStore: SystemStore
 ) : BindableItem<ItemSessionBinding>(
     session.id.hashCode().toLong()


### PR DESCRIPTION
## Issue
- close #383 

## Overview (Required)
- Delete unneeded listener field at `SpeechSessionItem.onFavoriteClickListener` and `SpeechSessionItem.onClickListener`

https://github.com/h3birth/conference-app-2019/blob/120feccb0acdbbc627ef5a24e01f231a77902cbb/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt#L53-L61

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
