### PR TITLE
Display sessions without entering search queries

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SearchActionCreator.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SearchActionCreator.kt
@@ -18,12 +18,12 @@ class SearchActionCreator @Inject constructor(
 ) : CoroutineScope by lifecycle.coroutineScope,
     ErrorHandler {
     fun search(query: String?, sessionContents: SessionContents) {
-        // if we do not have query, we should show speakers
+        // if we do not have query, we should show speakers and sessions
         if (query.isNullOrBlank()) {
             dispatcher.launchAndDispatch(
                 Action.SearchResultLoaded(
                     SearchResult(
-                        listOf(),
+                        sessionContents.sessions,
                         sessionContents.speakers,
                         query
                     )


### PR DESCRIPTION
## Issue
- close #406

## Overview (Required)
- Display sessions without entering search queries.

I just fixed this followed by the issue.
But it's was seems show only Speakers on purpose.
Is this change really correct or it was have something special reason?

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1439687/51073298-0f686380-16b2-11e9-99c3-38a4f2e9f9d2.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1439687/51073302-168f7180-16b2-11e9-9686-1bda20988c06.png" width="300" />
