### PR TITLE
Fixed that unneeded scrollbar is shown when switching tab

### DIFF
--- a/feature/session/src/main/res/layout/fragment_session_page.xml
+++ b/feature/session/src/main/res/layout/fragment_session_page.xml
@@ -17,6 +17,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginBottom="64dp"
+            android:scrollbars="none"
             >
 
             <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
## Issue
- close #410

## Overview (Required)
- Fixed that unneeded scrollbar is shown when switching tab.
Just one line 😄 

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1439687/51073843-4b9fc200-16ba-11e9-879f-248cb1d689c5.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/1439687/51073854-6ffb9e80-16ba-11e9-901f-e360dc6bddd2.gif" width="300" />

