### PR TITLE
Introduce Firebase Crashlytics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
         maven { url "https://dl.bintray.com/kotlin/ktor" }
         maven { url "http://kotlin.bintray.com/kotlin-dev" }
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
         classpath Dep.GradlePlugin.android
@@ -26,6 +27,7 @@ buildscript {
         classpath Dep.GradlePlugin.safeArgs
         classpath Dep.GradlePlugin.jetifier
         classpath Dep.GradlePlugin.licensesPlugin
+        classpath Dep.GradlePlugin.crashlytics
     }
 }
 

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -11,6 +11,7 @@ object Dep {
             "android.arch.navigation:navigation-safe-args-gradle-plugin:${AndroidX.Navigation.version}"
         val jetifier = "com.android.tools.build.jetifier:jetifier-processor:1.0.0-beta02"
         val licensesPlugin = "com.google.android.gms:oss-licenses-plugin:0.9.4"
+        val crashlytics = "io.fabric.tools:gradle:1.26.1"
     }
 
     object Test {
@@ -85,6 +86,7 @@ object Dep {
         val core = "com.google.firebase:firebase-core:16.0.4"
         val fireStore = "com.google.firebase:firebase-firestore:17.1.3"
         val auth = "com.google.firebase:firebase-auth:16.0.5"
+        val crashlytics = "com.crashlytics.sdk.android:crashlytics:2.9.8"
     }
 
     object PlayServices {

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'androidx.navigation.safeargs'
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'
+apply plugin: 'io.fabric'
 
 android {
     compileSdkVersion Versions.androidCompileSdkVersion
@@ -101,6 +102,7 @@ dependencies {
 
     implementation Dep.Firebase.core
     implementation Dep.Firebase.auth
+    implementation Dep.Firebase.crashlytics
 
     api Dep.Dagger.core
     api Dep.Dagger.androidSupport

--- a/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/App.kt
+++ b/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/App.kt
@@ -6,11 +6,13 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.core.provider.FontRequest
 import androidx.emoji.text.EmojiCompat
 import androidx.emoji.text.FontRequestEmojiCompatConfig
+import com.crashlytics.android.Crashlytics
 import com.google.firebase.FirebaseApp
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreSettings
 import dagger.android.AndroidInjector
 import dagger.android.DaggerApplication
+import io.fabric.sdk.android.Fabric
 import io.github.droidkaigi.confsched2019.di.createAppComponent
 import io.github.droidkaigi.confsched2019.ext.android.changedForever
 import io.github.droidkaigi.confsched2019.system.actioncreator.SystemActionCreator
@@ -29,6 +31,7 @@ open class App : DaggerApplication() {
         setupFont()
         setupEmojiCompat()
         setupFirestore()
+        setupCrashlytics()
         systemStore.systemProperty.changedForever {
             // listening
         }
@@ -75,6 +78,10 @@ open class App : DaggerApplication() {
                 }
             })
         EmojiCompat.init(config)
+    }
+
+    private fun setupCrashlytics() {
+        Fabric.with(this, Crashlytics())
     }
 
     override fun applicationInjector(): AndroidInjector<out DaggerApplication> {

--- a/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/App.kt
+++ b/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/App.kt
@@ -28,10 +28,10 @@ open class App : DaggerApplication() {
     override fun onCreate() {
         super.onCreate()
 
+        setupCrashlytics()
         setupFont()
         setupEmojiCompat()
         setupFirestore()
-        setupCrashlytics()
         systemStore.systemProperty.changedForever {
             // listening
         }


### PR DESCRIPTION
## Issue
- close [#125](https://github.com/DroidKaigi/conference-app-2019/issues/125)

## Overview (Required)
- Introduce Firebase Crashlytics
- But, Unfortunately, the logs are not clean. I do not know the current cause.
   - Maybe, Firebase administrators of DroidKaigi 2019 think that configuration is necessary.

```
I/FirebaseAuth: [FirebaseAuth:] Loading module via FirebaseOptions.
I/FirebaseAuth: [FirebaseAuth:] Preparing to create service connection to gms implementation
D/FirebaseApp: com.google.firebase.crash.FirebaseCrash is not linked. Skipping initialization.
I/FirebaseInitProvider: FirebaseApp initialization successful
D/Fabric: Falling back to Crashlytics key lookup from Manifest <-- ???
D/Fabric: Falling back to Crashlytics key lookup from Strings <-- ???
D/Fabric: Falling back to Crashlytics key lookup from Manifest
D/Fabric: Falling back to Crashlytics key lookup from Strings
D/Fabric: Falling back to Crashlytics key lookup from Manifest
D/Fabric: Falling back to Crashlytics key lookup from Strings
D/Fabric: Generating Crashlytics ApiKey from google_app_id in Strings
D/Fabric: Build ID is: 613b857d-7a18-4561-91b1-2d350915cb55
I/CrashlyticsCore: Initializing Crashlytics 2.6.7.30
D/CrashlyticsCore: Installer package name is: null
D/Fabric: Using AdvertisingInfo from Preference Store
D/Fabric: Falling back to Crashlytics key lookup from Manifest
D/Fabric: Falling back to Crashlytics key lookup from Strings
D/Fabric: Generating Crashlytics ApiKey from google_app_id in Strings
D/Fabric: Falling back to Crashlytics key lookup from Manifest
D/Fabric: Falling back to Crashlytics key lookup from Strings
D/Fabric: Build ID is: 613b857d-7a18-4561-91b1-2d350915cb55
D/Fabric: Falling back to Crashlytics key lookup from Manifest
D/Fabric: Falling back to Crashlytics key lookup from Strings
D/CrashlyticsCore: Exception handling initialization successful
D/Fabric: Initializing io.fabric.sdk.android:fabric [Version: 1.4.7.30], with the following kits:
    com.crashlytics.sdk.android:crashlytics [Version: 2.9.8.30]
    com.crashlytics.sdk.android:beta [Version: 1.2.10.27]
    com.crashlytics.sdk.android:answers [Version: 1.4.6.30]
    com.crashlytics.sdk.android.crashlytics-core [Version: 2.6.7.30]
I/CrashlyticsInitProvider: CrashlyticsInitProvider initialization successful
D/CrashlyticsCore: Opening a new session with ID 5C3A1626038F-0001-3AAA-263ACB10691E
D/Fabric: Build ID is: 613b857d-7a18-4561-91b1-2d350915cb55
D/Fabric: Build ID is: 613b857d-7a18-4561-91b1-2d350915cb55
D/Fabric: Reading cached settings...
D/Fabric: Loaded cached settings: {"settings_version":2,"cache_duration":7200,"features":{"collect_logged_exceptions":true,"collect_reports":true,"collect_analytics":true,"prompt_enabled":false,"push_enabled":true,"firebase_crashlytics_enabled":true},"analytics":{"url":"https:\/\/e.crashlytics.com\/spi\/v2\/events","flush_interval_secs":120,"max_file_count_per_send":1,"track_custom_events":true,"track_predefined_events":true,"track_view_controllers":false,"flush_on_background":true,"max_byte_size_per_file":40000,"max_pending_send_file_count":20,"sampling_rate":1,"forward_to_google_analytics":false,"include_purchase_events_in_forwarded_events":false},"beta":{"update_suspend_duration":1209600,"update_endpoint":""},"app":{"identifier":"io.github.droidkaigi.confsched2019.debug","status":"activated","url":"https:\/\/api.crashlytics.com\/spi\/v1\/platforms\/android\/apps\/io.github.droidkaigi.confsched2019.debug","reports_url":"https:\/\/reports.crashlytics.com\/spi\/v1\/platforms\/android\/apps\/io.github.droidkaigi.confsched2019.debug\/reports","ndk_reports_url":"https:\/\/reports.crashlytics.com\/sdk-api\/v1\/platforms\/android\/apps\/io.github.droidkaigi.confsched2019.debug\/minidumps","update_required":true},"session":{"log_buffer_size":64000,"max_chained_exception_depth":16,"max_complete_sessions_count":4,"max_custom_exception_events":8,"max_custom_key_value_pairs":64,"identifier_mask":255},"prompt":{"title":"Send Crash Report?","message":"Looks like we crashed! Please help us fix the problem by sending a crash report.","send_button_title":"Send","show_cancel_button":true,"cancel_button_title":"Don't Send","show_always_send_button":true,"always_send_button_title":"Always Send"},"expires_at":1547317119621}
D/Fabric: Returning cached settings.
D/Fabric: Server says an update is required - forcing a full App update.
D/Fabric: App icon resource ID is 2131689472
D/Fabric: Falling back to Crashlytics key lookup from Manifest
D/Fabric: Falling back to Crashlytics key lookup from Strings
D/Fabric: Generating Crashlytics ApiKey from google_app_id in Strings
D/Fabric: Build ID is: 613b857d-7a18-4561-91b1-2d350915cb55
D/Fabric: Sending app info to https://api.crashlytics.com/spi/v1/platforms/android/apps/io.github.droidkaigi.confsched2019.debug
D/Fabric: App icon hash is 4059963d9b8df5774480757728b3a49350932b06
D/Fabric: App icon size is 144x144
D/Fabric: Update app request ID: fc1bf0d7eb0c0022a99d3a55de4c63bd
D/Fabric: Result was 204
D/CrashlyticsCore: Initialization marker file created.
D/Fabric: Falling back to Crashlytics key lookup from Manifest
D/Fabric: Falling back to Crashlytics key lookup from Strings
D/Fabric: Generating Crashlytics ApiKey from google_app_id in Strings
D/CrashlyticsCore: Registered Firebase Analytics event listener
D/CrashlyticsCore: Finalizing previously open sessions.
D/CrashlyticsCore: Closing open sessions.
D/CrashlyticsCore: Closing session: 5C3A14B203A8-0001-39E1-263ACB10691E
D/CrashlyticsCore: Collecting session parts for ID 5C3A14B203A8-0001-39E1-263ACB10691E
D/CrashlyticsCore: Session 5C3A14B203A8-0001-39E1-263ACB10691E has fatal exception: false
D/CrashlyticsCore: Session 5C3A14B203A8-0001-39E1-263ACB10691E has non-fatal exceptions: false
D/CrashlyticsCore: No events present for session ID 5C3A14B203A8-0001-39E1-263ACB10691E
D/CrashlyticsCore: Removing session part files for ID 5C3A14B203A8-0001-39E1-263ACB10691E
D/CrashlyticsCore: Closed all previously open sessions
D/CrashlyticsCore: Initialization marker file removed: true
D/CrashlyticsCore: Starting report processing in 1.0 second(s)...
```