### PR TITLE
Enable org.gradle.parallel for faster build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryErr
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official


### PR DESCRIPTION
## Issue
There's no issues filed for this.

## Overview (Required)
I enabled `org.gradle.parallel` to take advantage of the multi-module setup. The build will run tasks in parallel where possible.

The amount of improved build time depends on the spec of your machine, but it should be faster in general.

Gradle scan reports
Enabled: https://scans.gradle.com/s/y5azqvabdv5yq
Disabled: https://scans.gradle.com/s/rz3r5yqbwt7ji
