### PR TITLE
Fix issue #187 use defaultLang instead of systemStore.lang

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
@@ -27,7 +27,6 @@ import io.github.droidkaigi.confsched2019.session.ui.item.SpeakerItem
 import io.github.droidkaigi.confsched2019.session.ui.store.SessionContentsStore
 import io.github.droidkaigi.confsched2019.session.ui.widget.DaggerFragment
 import io.github.droidkaigi.confsched2019.system.actioncreator.ActivityActionCreator
-import io.github.droidkaigi.confsched2019.system.store.SystemStore
 import io.github.droidkaigi.confsched2019.util.ProgressTimeLatch
 import javax.inject.Inject
 
@@ -35,7 +34,6 @@ class SessionDetailFragment : DaggerFragment() {
     private lateinit var binding: FragmentSessionDetailBinding
 
     @Inject lateinit var sessionContentsActionCreator: SessionContentsActionCreator
-    @Inject lateinit var systemStore: SystemStore
     @Inject lateinit var sessionContentsStore: SessionContentsStore
     @Inject lateinit var speakerItemFactory: SpeakerItem.Factory
     @Inject lateinit var activityActionCreator: ActivityActionCreator
@@ -134,10 +132,10 @@ class SessionDetailFragment : DaggerFragment() {
             session.room.name
         )
         binding.sessionIntendedAudienceDescription.text = session.intendedAudience
-        binding.categoryChip.text = session.category.name.getByLang(systemStore.lang)
+        binding.categoryChip.text = session.category.name.getByLang(defaultLang())
 
         session.message?.let { message ->
-            binding.sessionMessage.text = message.getByLang(systemStore.lang)
+            binding.sessionMessage.text = message.getByLang(defaultLang())
         }
 
         val sessionItems = session

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionPageFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionPageFragment.kt
@@ -33,7 +33,6 @@ import io.github.droidkaigi.confsched2019.session.ui.store.SessionContentsStore
 import io.github.droidkaigi.confsched2019.session.ui.store.SessionPageStore
 import io.github.droidkaigi.confsched2019.session.ui.store.SessionPagesStore
 import io.github.droidkaigi.confsched2019.session.ui.widget.DaggerFragment
-import io.github.droidkaigi.confsched2019.system.store.SystemStore
 import io.github.droidkaigi.confsched2019.widget.BottomSheetBehavior
 import io.github.droidkaigi.confsched2019.widget.FilterChip
 import io.github.droidkaigi.confsched2019.widget.onCheckedChanged
@@ -48,7 +47,6 @@ class SessionPageFragment : DaggerFragment() {
     @Inject lateinit var sessionContentsActionCreator: SessionContentsActionCreator
     @Inject lateinit var sessionPagesActionCreator: SessionPagesActionCreator
     @Inject lateinit var sessionPageActionCreator: SessionPageActionCreator
-    @Inject lateinit var systemStore: SystemStore
     @Inject lateinit var sessionStore: SessionContentsStore
     @Inject lateinit var sessionPageStoreFactory: SessionPageStore.Factory
     @Inject lateinit var sessionPagesStoreProvider: Provider<SessionPagesStore>
@@ -107,7 +105,7 @@ class SessionPageFragment : DaggerFragment() {
             )
             binding.sessionsFilterCategoryChip.setupFilter(
                 contents.category
-            ) { category -> category.name.getByLang(systemStore.lang) }
+            ) { category -> category.name.getByLang(defaultLang()) }
             binding.sessionsFilterLangChip.setupFilter(
                 contents.langs
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
@@ -24,7 +24,6 @@ import io.github.droidkaigi.confsched2019.model.defaultLang
 import io.github.droidkaigi.confsched2019.session.R
 import io.github.droidkaigi.confsched2019.session.databinding.ItemSessionBinding
 import io.github.droidkaigi.confsched2019.session.ui.actioncreator.SessionContentsActionCreator
-import io.github.droidkaigi.confsched2019.system.store.SystemStore
 import io.github.droidkaigi.confsched2019.util.lazyWithParam
 import jp.wasabeef.picasso.transformations.CropCircleTransformation
 import kotlin.math.max
@@ -34,8 +33,7 @@ class SpeechSessionItem @AssistedInject constructor(
     @Assisted val navDirections: NavDirections,
     @Assisted val addPaddingForTime: Boolean,
     val navController: NavController,
-    val sessionContentsActionCreator: SessionContentsActionCreator,
-    val systemStore: SystemStore
+    val sessionContentsActionCreator: SessionContentsActionCreator
 ) : BindableItem<ItemSessionBinding>(
     session.id.hashCode().toLong()
 ), SessionItem {
@@ -71,12 +69,12 @@ class SpeechSessionItem @AssistedInject constructor(
                 speechSession.timeInMinutes,
                 speechSession.room.name
             )
-            categoryChip.text = speechSession.category.name.getByLang(systemStore.lang)
+            categoryChip.text = speechSession.category.name.getByLang(defaultLang())
 
             bindSpeaker()
 
             speechSession.message?.let { message ->
-                this@with.message.text = message.getByLang(systemStore.lang)
+                this@with.message.text = message.getByLang(defaultLang())
             }
         }
     }


### PR DESCRIPTION
## Issue
- close #187 

## Overview (Required)
- when user changes device's language some `Chip` s are not updated until reloading/re-binding

This PR changes:

- use `defaultLang()` instead of `systemStore.lang`

## Links
- #376 

## Screenshot
Before | After
:--: | :--:
![before](https://user-images.githubusercontent.com/7608725/51081781-38810680-173b-11e9-8fd4-f6b8db52765a.gif) | ![after](https://user-images.githubusercontent.com/7608725/51081786-73833a00-173b-11e9-84f8-90f3f7b2f214.gif)
