### PR TITLE
Disable Gradle's parallel option on CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ docker_env:
     environment:
       <<: *cache_version_keys
       JAVA_OPTS: "-Xms512m -Xmx2048m"
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false'
 
   go_defaults: &go_defaults
     working_directory: ~/conference-app-2019


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- Disable Gradle's parallel option on CI.
- Because Gradle's memory allocation in parallel uses many memories.

## Links
- None

## Screenshot
- None
