### PR TITLE
Fix "Droidkaigi" to camelcase

### DIFF
--- a/frontendcomponent/androidcomponent/src/main/res/values-ja/strings.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values-ja/strings.xml
@@ -3,7 +3,7 @@
     <string name="announce_label">お知らせ</string>
     <string name="map_label">フロアマップ</string>
     <string name="session_label">タイムライン</string>
-    <string name="about_label">Droidkaigiとは</string>
+    <string name="about_label">DroidKaigi とは</string>
     <string name="sponsor_label">スポンサーページ</string>
     <string name="survey_label">全体アンケート</string>
     <string name="description_filter_applied">フィルター%1$sを適用</string>


### PR DESCRIPTION
## Overview (Required)

- `Droidkaigi` -> `DroidKaigi`

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://user-images.githubusercontent.com/1744778/51085580-f4aff080-177e-11e9-8a78-4722d2d4ac86.png" width="300" />
