### PR TITLE
Improve SessionsItemDecoration performance

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
@@ -10,6 +10,7 @@ import android.util.SparseArray
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.util.contains
 import androidx.core.util.forEach
 import androidx.recyclerview.widget.RecyclerView
 import com.soywiz.klock.DateTimeSpan
@@ -41,6 +42,7 @@ class SessionsItemDecoration(
     ).toFloat()
     // Keep SparseArray instance on property to avoid object creation in every onDrawOver()
     private val adapterPositionToViews = SparseArray<View>()
+    private val sessionTimeByAdapterPosition = SparseArray<String>()
 
     private data class TimeText(
         val text: String,
@@ -166,8 +168,14 @@ class SessionsItemDecoration(
             return null
         }
 
-        val item = groupAdapter.getItem(position) as? SessionItem ?: return null
-        return item.session.startTime
-            .plus(displayTimezoneOffset.value).toString("HH:mm")
+        return if (sessionTimeByAdapterPosition.contains(position)) {
+            sessionTimeByAdapterPosition.get(position)
+        } else {
+            val item = groupAdapter.getItem(position) as? SessionItem ?: return null
+            item.session.startTime.plus(displayTimezoneOffset.value)
+                .toString("HH:mm").also {
+                    sessionTimeByAdapterPosition.put(position, it)
+                }
+        }
     }
 }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
@@ -10,9 +10,9 @@ import android.util.SparseArray
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
-import androidx.core.util.contains
 import androidx.core.util.forEach
 import androidx.recyclerview.widget.RecyclerView
+import com.soywiz.klock.DateTime
 import com.soywiz.klock.DateTimeSpan
 import com.xwray.groupie.GroupAdapter
 import io.github.droidkaigi.confsched2019.session.R
@@ -42,7 +42,7 @@ class SessionsItemDecoration(
     ).toFloat()
     // Keep SparseArray instance on property to avoid object creation in every onDrawOver()
     private val adapterPositionToViews = SparseArray<View>()
-    private val sessionTimeByAdapterPosition = SparseArray<String>()
+    private val cachedDateTimeText = HashMap<DateTime, String>()
 
     private data class TimeText(
         val text: String,
@@ -168,14 +168,11 @@ class SessionsItemDecoration(
             return null
         }
 
-        return if (sessionTimeByAdapterPosition.contains(position)) {
-            sessionTimeByAdapterPosition.get(position)
-        } else {
-            val item = groupAdapter.getItem(position) as? SessionItem ?: return null
-            item.session.startTime.plus(displayTimezoneOffset.value)
+        val item = groupAdapter.getItem(position) as? SessionItem ?: return null
+        return cachedDateTimeText[item.session.startTime]
+            ?: item.session.startTime.plus(displayTimezoneOffset.value)
                 .toString("HH:mm").also {
-                    sessionTimeByAdapterPosition.put(position, it)
+                    cachedDateTimeText[item.session.startTime] = it
                 }
-        }
     }
 }


### PR DESCRIPTION

## Issue
- close #439 

## Overview (Required)
- calculating session time on each onDrawOver that causes unnecessary memory allocation. (it is higher cost needed to calculate DateTime in onDrawOver)

## Links
-

## Screenshot
Before | After
:--: | :--:
![performance](https://user-images.githubusercontent.com/7608725/51085510-b960f200-177d-11e9-8b3d-c84d5f462b4a.jpg) | ![after](https://user-images.githubusercontent.com/7608725/51086374-90def500-1789-11e9-886d-b3a38cdf6e2d.jpg)

before: increase memory usage about 500MB and more
after: memory usage about 260MB