### PR TITLE
Remove injection call from subclass of DaggerFragment

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
@@ -14,7 +14,6 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.AndroidSupportInjection
 import io.github.droidkaigi.confsched2019.di.PageScope
 import io.github.droidkaigi.confsched2019.ext.android.changed
 import io.github.droidkaigi.confsched2019.model.LoadingState
@@ -59,7 +58,6 @@ class SessionDetailFragment : DaggerFragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        AndroidSupportInjection.inject(this)
 
         sessionDetailFragmentArgs = SessionDetailFragmentArgs.fromBundle(arguments)
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SpeakerFragment.kt
@@ -12,7 +12,6 @@ import androidx.navigation.NavController
 import com.soywiz.klock.DateTimeSpan
 import dagger.Module
 import dagger.Provides
-import dagger.android.support.AndroidSupportInjection
 import io.github.droidkaigi.confsched2019.di.PageScope
 import io.github.droidkaigi.confsched2019.ext.android.changed
 import io.github.droidkaigi.confsched2019.model.defaultLang
@@ -44,7 +43,6 @@ class SpeakerFragment : DaggerFragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        AndroidSupportInjection.inject(this)
 
         speakerFragmentArgs = SpeakerFragmentArgs.fromBundle(arguments)
 


### PR DESCRIPTION
## Issue
- close #448 

## Overview (Required)
- I roughly searched with the command: `git grep "AndroidSupportInjection.inject("` and deleted the lines. Please tell me any oversights.

## Links
- none

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
