### PR TITLE
Update coroutine version with Ktor version

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -70,7 +70,7 @@ object Dep {
         val version = "1.3.11"
         val stdlibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:$version"
         val stdlibJvm = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$version"
-        val coroutinesVersion = "1.0.1"
+        val coroutinesVersion = "1.1.0"
         val coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
         val androidCoroutinesDispatcher =
             "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
@@ -107,14 +107,13 @@ object Dep {
     }
 
     object Ktor {
-        val version = "1.0.1"
-        val iosVersion = "1.1.1"
+        val version = "1.1.1"
         val clientCommon = "io.ktor:ktor-client-core:$version"
         val clientAndroid = "io.ktor:ktor-client-okhttp:$version"
-        val clientIos = "io.ktor:ktor-client-ios:$iosVersion"
+        val clientIos = "io.ktor:ktor-client-ios:$version"
         val jsonCommon = "io.ktor:ktor-client-json:$version"
         val jsonJvm = "io.ktor:ktor-client-json-jvm:$version"
-        val jsonNative = "io.ktor:ktor-client-json-native:$iosVersion"
+        val jsonNative = "io.ktor:ktor-client-json-native:$version"
     }
 
     object OkHttp {


### PR DESCRIPTION
## Issue
- close #455

## Overview (Required)
- Because we use old android dispatcher. the app cause crash. So we use new android coroutine dispatcher.
