### PR TITLE
Remove last item divider on About screen

### DIFF
--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2019/about/ui/widget/DottedItemDecoration.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2019/about/ui/widget/DottedItemDecoration.kt
@@ -8,7 +8,6 @@ import android.graphics.Rect
 import android.graphics.Path
 import android.view.View
 import androidx.core.content.ContextCompat
-import androidx.core.view.forEach
 import androidx.core.view.forEachIndexed
 import androidx.core.view.size
 import androidx.recyclerview.widget.RecyclerView
@@ -54,8 +53,7 @@ class DottedItemDecoration private constructor(
                 this@DottedItemDecoration.gap.toFloat(),
                 this@DottedItemDecoration.gap.toFloat()
             ),
-            0f
-        )
+            0f)
     }
 
     override fun getItemOffsets(

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2019/about/ui/widget/DottedItemDecoration.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2019/about/ui/widget/DottedItemDecoration.kt
@@ -9,6 +9,8 @@ import android.graphics.Path
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.core.view.forEach
+import androidx.core.view.forEachIndexed
+import androidx.core.view.size
 import androidx.recyclerview.widget.RecyclerView
 
 class DottedItemDecoration private constructor(
@@ -52,7 +54,8 @@ class DottedItemDecoration private constructor(
                 this@DottedItemDecoration.gap.toFloat(),
                 this@DottedItemDecoration.gap.toFloat()
             ),
-            0f)
+            0f
+        )
     }
 
     override fun getItemOffsets(
@@ -72,11 +75,15 @@ class DottedItemDecoration private constructor(
         val right = (parent.width - paddingRight).toFloat()
 
         val path = Path()
-        parent.forEach { child ->
+        val lastIndex = parent.size - 1
+        parent.forEachIndexed { index, child ->
+
             val top = (child.bottom + width / 2).toFloat()
 
-            path.moveTo(left, top)
-            path.lineTo(right, top)
+            if (lastIndex != index) {
+                path.moveTo(left, top)
+                path.lineTo(right, top)
+            }
         }
         c.drawPath(path, paint)
     }


### PR DESCRIPTION
## Issue
- close #188 

## Overview (Required)
- Remove last item divider on About screen

## Links


## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/35567403/51105545-9e00f000-182c-11e9-9db3-a27042bf982f.png" width="300" /> | <img src="https://user-images.githubusercontent.com/35567403/51105560-a5c09480-182c-11e9-829a-68abdb3cabbf.png" width="300" />
