### PR TITLE
Hide header shadow when list empty

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetFavoriteSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetFavoriteSessionsFragment.kt
@@ -120,6 +120,9 @@ class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
             groupAdapter.update(items)
             applyTitleText()
             binding.shouldShowEmptyStateView = items.isEmpty()
+            if (items.isEmpty()) {
+                binding.sessionsListHeaderShadow.isVisible = false
+            }
         }
         sessionPagesStore.filters.changed(viewLifecycleOwner) {
             binding.isFiltered = it.isFiltered()


### PR DESCRIPTION
## Issue
- close #463 

## Overview (Required)
- After filtering, hide the session header if the session list is empty.  

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13705006/51108439-95f97e00-1835-11e9-8441-7c9636fb0545.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/13705006/51108694-55e6cb00-1836-11e9-9696-c132702ea6ed.gif" width="300" />

