### PR TITLE
Bumped Hyperion-Android 0.9.25 ( Fix for SecurityException on API 28)

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -137,7 +137,7 @@ object Dep {
     }
 
     object Hyperion {
-        val version = "0.9.24"
+        val version = "0.9.25"
         val hyperionPlugins = listOf(
             "com.willowtreeapps.hyperion:hyperion-core:$version",
             "com.willowtreeapps.hyperion:hyperion-attr:$version",


### PR DESCRIPTION
## Issue
- close #479

## Overview (Required)
- Bumped Hyperion version 0.9.25
- I didn't reproduce on my essential phone(Android9), so could you check if it is fix?

## Links
- none

## Screenshot
none
