### PR TITLE
fix: memory leaks from tablayout / recyclerview

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetDaySessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetDaySessionsFragment.kt
@@ -142,6 +142,11 @@ class BottomSheetDaySessionsFragment : DaggerFragment() {
         }
     }
 
+    override fun onDestroyView() {
+        binding.sessionsRecycler.adapter = null
+        super.onDestroyView()
+    }
+
     companion object {
         fun newInstance(
             args: BottomSheetDaySessionsFragmentArgs

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetFavoriteSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetFavoriteSessionsFragment.kt
@@ -147,6 +147,11 @@ class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
         }
     }
 
+    override fun onDestroyView() {
+        binding.sessionsRecycler.adapter = null
+        super.onDestroyView()
+    }
+
     private fun applyTitleText() {
         val linearLayoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
         val firstPosition = linearLayoutManager.findFirstVisibleItemPosition()

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionPagesFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionPagesFragment.kt
@@ -89,6 +89,11 @@ class SessionPagesFragment : DaggerFragment() {
         }
     }
 
+    override fun onDestroyView(){
+        binding.sessionsTabLayout.setupWithViewPager(null)
+        super.onDestroyView()
+    }
+
     private fun setupSessionPager() {
         binding.sessionsTabLayout.setupWithViewPager(binding.sessionsViewpager)
         binding.sessionsViewpager.pageMargin =


### PR DESCRIPTION
## Issue
- close #366

## Overview (Required)
This fixes 2 memory leaks

### SessionPageFragment.sessionTabLayout

These 2 images show 1 leak
<img src="https://user-images.githubusercontent.com/1014262/51187932-3f1ca300-1920-11e9-9202-b1c215558740.jpg" width="300" /><img src="https://user-images.githubusercontent.com/1014262/51187931-3e840c80-1920-11e9-9809-14a8bb5e31cf.jpg" width="300" />  

### RecyclerView

RecyclerView should release adapter when the fragment destroy views.
https://stackoverflow.com/questions/35520946/leak-canary-recyclerview-leaking-madapter

The target is BottomSheetDaySessionsFragment and BottomSheetFavoriteSessionsFragment.
<img src="https://user-images.githubusercontent.com/1014262/51191498-dc2f0a00-1927-11e9-8d28-c7389a3e7a45.jpg" width="300" />
