### PR TITLE
Feature/475 debug icon

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ buildscript {
         classpath Dep.GradlePlugin.jetifier
         classpath Dep.GradlePlugin.licensesPlugin
         classpath Dep.GradlePlugin.crashlytics
+        classpath Dep.GradlePlugin.iconRibbonPlugin
     }
 }
 

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -12,6 +12,7 @@ object Dep {
         val jetifier = "com.android.tools.build.jetifier:jetifier-processor:1.0.0-beta02"
         val licensesPlugin = "com.google.android.gms:oss-licenses-plugin:0.9.4"
         val crashlytics = "io.fabric.tools:gradle:1.26.1"
+        val iconRibbonPlugin = "com.akaita.android:easylauncher:1.3.1"
     }
 
     object Test {

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -60,6 +60,16 @@ android {
     }
 }
 
+easylauncher {
+    buildTypes {
+        debug {
+            filters = [
+                    grayscaleFilter()
+            ]
+        }
+    }
+}
+
 dependencies {
     implementation project(":model")
     implementation project(":feature:session")

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -7,6 +7,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'androidx.navigation.safeargs'
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 apply plugin: 'io.fabric'
+apply plugin: 'com.akaita.android.easylauncher'
 
 android {
     compileSdkVersion Versions.androidCompileSdkVersion


### PR DESCRIPTION
## Issue
- close #475 

## Overview (Required)
- Use [Gradle plugin](https://github.com/akaita/easylauncher-gradle-plugin) to apply grayscale filter to debug icon.

## Links

## Screenshot

### Grayscale
<img width="87" alt="2019-01-16 1 14 14" src="https://user-images.githubusercontent.com/236528/51193385-16020f80-192c-11e9-9c85-35b9d6ed38c3.png">

### Ribbon
<img width="76" alt="2019-01-16 1 14 22" src="https://user-images.githubusercontent.com/236528/51193388-17333c80-192c-11e9-9f64-867e7d58ed37.png">

I think grayscale one is more clearner looks than ribbon one(maybe this is a plugin restriction). So I choose grayscale filter.
Is there any recommended other plugin (or approach) to modify debug icon?