### PR TITLE
Refactor DateTime and Time Zone

### DIFF
--- a/data/repository-impl/src/main/java/io/github/droidkaigi/confsched2019/data/repository/mapper/SessionMappers.kt
+++ b/data/repository-impl/src/main/java/io/github/droidkaigi/confsched2019/data/repository/mapper/SessionMappers.kt
@@ -2,15 +2,14 @@ package io.github.droidkaigi.confsched2019.data.repository.mapper
 
 import com.soywiz.klock.DateTime
 import com.soywiz.klock.hours
-import com.soywiz.klock.offset
 import io.github.droidkaigi.confsched2019.data.db.entity.SessionWithSpeakers
 import io.github.droidkaigi.confsched2019.data.db.entity.SpeakerEntity
 import io.github.droidkaigi.confsched2019.model.Category
+import io.github.droidkaigi.confsched2019.model.LocaledString
 import io.github.droidkaigi.confsched2019.model.Room
 import io.github.droidkaigi.confsched2019.model.Session
 import io.github.droidkaigi.confsched2019.model.SessionType
 import io.github.droidkaigi.confsched2019.model.Speaker
-import io.github.droidkaigi.confsched2019.model.LocaledString
 
 private val jstOffset = 9.hours
 
@@ -24,14 +23,14 @@ fun SessionWithSpeakers.toSession(
             id = session.id,
             // dayNumber is starts with 1.
             // Example: First day = 1, Second day = 2. So I plus 1 to period days
-            dayNumber = DateTime(session.stime).toOffset(jstOffset).dayOfYear
-                - firstDay.toOffset(jstOffset).dayOfYear + 1,
+            dayNumber = DateTime(session.stime).toOffset(jstOffset).dayOfYear -
+                firstDay.toOffset(jstOffset).dayOfYear + 1,
             startTime = DateTime.fromUnix(session.stime),
             endTime = DateTime.fromUnix(session.etime),
             title = LocaledString(
                 ja = session.title,
                 en = requireNotNull(session.englishTitle)
-                ),
+            ),
             desc = session.desc,
             room = requireNotNull(session.room).let { room ->
                 Room(room.id, room.name)
@@ -50,8 +49,8 @@ fun SessionWithSpeakers.toSession(
             id = session.id,
             // dayNumber is starts with 1.
             // Example: First day = 1, Second day = 2. So I plus 1 to period days
-            dayNumber = DateTime(session.stime).toOffset(jstOffset).dayOfYear
-                - firstDay.toOffset(jstOffset).dayOfYear + 1,
+            dayNumber = DateTime(session.stime).toOffset(jstOffset).dayOfYear -
+                firstDay.toOffset(jstOffset).dayOfYear + 1,
             startTime = DateTime.fromUnix(session.stime),
             endTime = DateTime.fromUnix(session.etime),
             title = LocaledString(session.title, requireNotNull(session.englishTitle)),

--- a/data/repository-impl/src/main/java/io/github/droidkaigi/confsched2019/data/repository/mapper/SessionMappers.kt
+++ b/data/repository-impl/src/main/java/io/github/droidkaigi/confsched2019/data/repository/mapper/SessionMappers.kt
@@ -1,6 +1,8 @@
 package io.github.droidkaigi.confsched2019.data.repository.mapper
 
 import com.soywiz.klock.DateTime
+import com.soywiz.klock.hours
+import com.soywiz.klock.offset
 import io.github.droidkaigi.confsched2019.data.db.entity.SessionWithSpeakers
 import io.github.droidkaigi.confsched2019.data.db.entity.SpeakerEntity
 import io.github.droidkaigi.confsched2019.model.Category
@@ -9,6 +11,8 @@ import io.github.droidkaigi.confsched2019.model.Session
 import io.github.droidkaigi.confsched2019.model.SessionType
 import io.github.droidkaigi.confsched2019.model.Speaker
 import io.github.droidkaigi.confsched2019.model.LocaledString
+
+private val jstOffset = 9.hours
 
 fun SessionWithSpeakers.toSession(
     speakerEntities: List<SpeakerEntity>,
@@ -20,7 +24,8 @@ fun SessionWithSpeakers.toSession(
             id = session.id,
             // dayNumber is starts with 1.
             // Example: First day = 1, Second day = 2. So I plus 1 to period days
-            dayNumber = DateTime(session.stime).dayOfYear - firstDay.dayOfYear + 1,
+            dayNumber = DateTime(session.stime).toOffset(jstOffset).dayOfYear
+                - firstDay.toOffset(jstOffset).dayOfYear + 1,
             startTime = DateTime.fromUnix(session.stime),
             endTime = DateTime.fromUnix(session.etime),
             title = LocaledString(
@@ -45,7 +50,8 @@ fun SessionWithSpeakers.toSession(
             id = session.id,
             // dayNumber is starts with 1.
             // Example: First day = 1, Second day = 2. So I plus 1 to period days
-            dayNumber = DateTime(session.stime).dayOfYear - firstDay.dayOfYear + 1,
+            dayNumber = DateTime(session.stime).toOffset(jstOffset).dayOfYear
+                - firstDay.toOffset(jstOffset).dayOfYear + 1,
             startTime = DateTime.fromUnix(session.stime),
             endTime = DateTime.fromUnix(session.etime),
             title = LocaledString(session.title, requireNotNull(session.englishTitle)),

--- a/feature/announcement/src/test/java/io/github/droidkaigi/confsched2019/AnnouncementDummyDatas.kt
+++ b/feature/announcement/src/test/java/io/github/droidkaigi/confsched2019/AnnouncementDummyDatas.kt
@@ -1,10 +1,13 @@
 package io.github.droidkaigi.confsched2019
 
 import com.soywiz.klock.DateTime
+import com.soywiz.klock.hours
 import com.soywiz.klock.minutes
 import io.github.droidkaigi.confsched2019.model.Announcement
 
-private val startTime = DateTime.createAdjusted(2019, 2, 7, 10, 0)
+private val startTime =
+    DateTime.createAdjusted(2019, 2, 7, 10, 0).toOffsetUnadjusted(9.hours).utc
+
 fun dummyAnnouncementsData(): List<Announcement> {
     return listOf(
         Announcement(

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionPagesFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionPagesFragment.kt
@@ -14,7 +14,6 @@ import androidx.fragment.app.FragmentStatePagerAdapter
 import androidx.lifecycle.Lifecycle
 import androidx.viewpager.widget.ViewPager
 import com.soywiz.klock.DateTime
-import com.soywiz.klock.DateTimeSpan
 import com.soywiz.klock.hours
 import dagger.Module
 import dagger.Provides

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionPagesFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionPagesFragment.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.viewpager.widget.ViewPager
 import com.soywiz.klock.DateTime
 import com.soywiz.klock.DateTimeSpan
+import com.soywiz.klock.hours
 import dagger.Module
 import dagger.Provides
 import dagger.android.ContributesAndroidInjector
@@ -128,8 +129,7 @@ class SessionPagesFragment : DaggerFragment() {
             }
         }
 
-        val timezoneOffset = DateTimeSpan(hours = 9) // to JST
-        val jstNow = DateTime.now().plus(timezoneOffset)
+        val jstNow = DateTime.now().toOffset(9.hours)
         if (jstNow.yearInt == 2019 && jstNow.month1 == 2 && jstNow.dayOfMonth == 8) {
             binding.sessionsViewpager.currentItem = 1
         }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/SessionsItemDecoration.kt
@@ -142,7 +142,7 @@ class SessionsItemDecoration(
     }
 
     private val displayTimezoneOffset = lazy {
-        DateTimeSpan(hours = 9) // FIXME Get from device setting
+        DateTimeSpan(hours = 9).timeSpan // FIXME Get from device setting
     }
 
     private fun calcTimeText(position: Int, view: View): TimeText? {
@@ -170,7 +170,7 @@ class SessionsItemDecoration(
 
         val item = groupAdapter.getItem(position) as? SessionItem ?: return null
         return cachedDateTimeText[item.session.startTime]
-            ?: item.session.startTime.plus(displayTimezoneOffset.value)
+            ?: item.session.startTime.toOffset(displayTimezoneOffset.value)
                 .toString("HH:mm").also {
                     cachedDateTimeText[item.session.startTime] = it
                 }

--- a/feature/session/src/test/java/io/github/droidkaigi/confsched2019/SessionDummyDatas.kt
+++ b/feature/session/src/test/java/io/github/droidkaigi/confsched2019/SessionDummyDatas.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched2019
 
 import com.soywiz.klock.DateTime
+import com.soywiz.klock.hours
 import com.soywiz.klock.minutes
 import io.github.droidkaigi.confsched2019.model.Category
 import io.github.droidkaigi.confsched2019.model.LocaledString
@@ -8,7 +9,9 @@ import io.github.droidkaigi.confsched2019.model.Room
 import io.github.droidkaigi.confsched2019.model.Session
 import io.github.droidkaigi.confsched2019.model.SessionType
 
-private val startTime = DateTime.createAdjusted(2019, 2, 7, 10, 0)
+private val startTime =
+    DateTime.createAdjusted(2019, 2, 7, 10, 0).toOffsetUnadjusted(9.hours).utc
+
 fun dummySessionData(): List<Session> {
     return listOf(
         Session.ServiceSession(

--- a/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/util/SessionAlarm.kt
+++ b/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/util/SessionAlarm.kt
@@ -6,7 +6,6 @@ import android.app.PendingIntent
 import android.content.Context
 import android.os.Build
 import com.soywiz.klock.DateTimeSpan
-import com.soywiz.klock.TimeSpan
 import com.soywiz.klock.minutes
 import io.github.droidkaigi.confsched2019.broadcastreceiver.NotificationBroadcastReceiver
 import io.github.droidkaigi.confsched2019.model.Session

--- a/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/util/SessionAlarm.kt
+++ b/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/util/SessionAlarm.kt
@@ -6,6 +6,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.os.Build
 import com.soywiz.klock.DateTimeSpan
+import com.soywiz.klock.TimeSpan
 import com.soywiz.klock.minutes
 import io.github.droidkaigi.confsched2019.broadcastreceiver.NotificationBroadcastReceiver
 import io.github.droidkaigi.confsched2019.model.Session
@@ -49,9 +50,9 @@ class SessionAlarm @Inject constructor(private val app: Application) {
     }
 
     private fun createAlarmIntent(session: Session): PendingIntent {
-        val timezoneOffset = DateTimeSpan(hours = 9) // FIXME Get from device setting
-        val displaySTime = session.startTime.plus(timezoneOffset).format("HH:mm")
-        val displayETime = session.endTime.plus(timezoneOffset).format("HH:mm")
+        val timezoneOffset = DateTimeSpan(hours = 9).timeSpan // FIXME Get from device setting
+        val displaySTime = session.startTime.toOffset(timezoneOffset).format("HH:mm")
+        val displayETime = session.endTime.toOffset(timezoneOffset).format("HH:mm")
         val sessionTitle = app.getString(
             R.string.notification_message_session_title,
             when (session) {

--- a/model/src/commonMain/kotlin/Session.kt
+++ b/model/src/commonMain/kotlin/Session.kt
@@ -3,7 +3,7 @@ package io.github.droidkaigi.confsched2019.model
 import com.soywiz.klock.DateTime
 import com.soywiz.klock.DateTimeSpan
 import com.soywiz.klock.TimeSpan
-import com.soywiz.klock.TimezoneOffset
+import com.soywiz.klock.hours
 
 sealed class Session(
     open val id: String,
@@ -49,24 +49,27 @@ sealed class Session(
         override val isFavorited: Boolean
     ) : Session(id, dayNumber, startTime, endTime, room, isFavorited)
 
-    val startDayText by lazy { startTime.format("yyyy.M.d") }
+    val startDayText by lazy { startTime.toOffset(9.hours).format("yyyy.M.d") }
 
     fun timeSummary(lang: Lang, timezoneOffset: DateTimeSpan) = buildString {
+        val startTimeTZ = startTime.toOffset(timezoneOffset.timeSpan)
+        val endTimeTZ = endTime.toOffset(timezoneOffset.timeSpan)
+
         // ex: 2月2日 10:20-10:40
         if (lang == Lang.EN) {
-            append(startTime.format("M"))
+            append(startTimeTZ.format("M"))
             append(".")
-            append(startTime.format("d"))
+            append(startTimeTZ.format("d"))
         } else {
-            append(startTime.format("M"))
+            append(startTimeTZ.format("M"))
             append("月")
-            append(startTime.format("d"))
+            append(startTimeTZ.format("d"))
             append("日")
         }
         append(" ")
-        append(startTime.plus(timezoneOffset).format("HH:mm"))
+        append(startTimeTZ.format("HH:mm"))
         append(" - ")
-        append(endTime.plus(timezoneOffset).format("HH:mm"))
+        append(endTimeTZ.format("HH:mm"))
     }
 
     fun summary(lang: Lang, timezoneOffset: DateTimeSpan) = buildString {

--- a/model/src/jvmTest/kotlin/io/github/droidkaigi/confsched2019/model/DateTimeTest.kt
+++ b/model/src/jvmTest/kotlin/io/github/droidkaigi/confsched2019/model/DateTimeTest.kt
@@ -1,18 +1,67 @@
 package io.github.droidkaigi.confsched2019.model
 
 import com.soywiz.klock.DateFormat
+import com.soywiz.klock.DateTime
+import com.soywiz.klock.DateTimeTz
+import com.soywiz.klock.hours
 import com.soywiz.klock.parse
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class DateTimeTest {
 
+    private val dateFormat = DateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
+    private val eventTimeString = "2019-02-07T08:12:34+09:00"
+    private val jstOffset = 9.hours
+
     @Test fun dateFormat() {
-        assertEquals(
-            16, DateFormat("""yyyy-MM-dd'T'HH:mm:ss""")
-                .parse("2018-10-08T16:32:59")
-                .utc
-                .hours
-        )
+        val parsedTimeUnixMillis = dateFormat.parse(eventTimeString).utc.unixMillisLong
+        val parsedTime: DateTime = DateTime.fromUnix(parsedTimeUnixMillis)
+        val parsedTimeTZ: DateTimeTz = parsedTime.toOffset(jstOffset)
+
+        assertEquals(2019, parsedTime.yearInt)
+        assertEquals(2, parsedTime.month1)
+        assertEquals(6, parsedTime.dayOfMonth)
+        assertEquals(23, parsedTime.hours)
+        assertEquals(12, parsedTime.minutes)
+        assertEquals(34, parsedTime.seconds)
+
+        assertEquals(2019, parsedTimeTZ.yearInt)
+        assertEquals(2, parsedTimeTZ.month1)
+        assertEquals(7, parsedTimeTZ.dayOfMonth)
+        assertEquals(8, parsedTimeTZ.hours)
+        assertEquals(12, parsedTimeTZ.minutes)
+        assertEquals(34, parsedTimeTZ.seconds)
+        assertEquals(9.0, parsedTimeTZ.offset.time.hours)
+
+        assertEquals(37, parsedTime.dayOfYear)
+        assertEquals(38, parsedTimeTZ.dayOfYear)
+
+        assertEquals(parsedTime.unixMillisLong, parsedTimeTZ.utc.unixMillisLong)
+    }
+
+    @Test fun createAdjusted() {
+        val sessionTime = DateTime.createAdjusted(2019, 2, 7, 8, 12, 34)
+        val sessionTimeTZ = sessionTime.toOffsetUnadjusted(jstOffset)
+
+        assertEquals(2019, sessionTime.yearInt)
+        assertEquals(2, sessionTime.month1)
+        assertEquals(7, sessionTime.dayOfMonth)
+        assertEquals(8, sessionTime.hours)
+        assertEquals(12, sessionTime.minutes)
+        assertEquals(34, sessionTime.seconds)
+
+        assertEquals(2019, sessionTimeTZ.yearInt)
+        assertEquals(2, sessionTimeTZ.month1)
+        assertEquals(7, sessionTimeTZ.dayOfMonth)
+        assertEquals(8, sessionTimeTZ.hours)
+        assertEquals(12, sessionTimeTZ.minutes)
+        assertEquals(34, sessionTimeTZ.seconds)
+        assertEquals(9.0, sessionTimeTZ.offset.time.hours)
+
+        assertEquals(sessionTime.minus(jstOffset).unixMillisLong, sessionTimeTZ.utc.unixMillisLong)
+
+        val parsedTimeUnixMillis = dateFormat.parse(eventTimeString).utc.unixMillisLong
+        assertEquals(parsedTimeUnixMillis, sessionTimeTZ.utc.unixMillisLong)
     }
 }


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)

This PR improve about time zone adjustment.

* Calculate `dayNumber` based on JST.
* Use `toOffset` instead of `plus`.
* Use `toOffsetUnadjusted` to adjust the date components to be JST.

klock's `DateTime` represents a Date in UTC (GMT+00).
When time zone adjusting, we should convert to DateTimeTz.

I also wrote a test code to verify the operation of `DateTime`.

what do you think about this?

## Links
-


