### PR TITLE
Enable gzip compression when api calls

### DIFF
--- a/data/api-impl/src/iosMain/kotlin/io/github/droidkaigi/confsched2019/data/api/ApiComponent.kt
+++ b/data/api-impl/src/iosMain/kotlin/io/github/droidkaigi/confsched2019/data/api/ApiComponent.kt
@@ -14,7 +14,7 @@ internal fun generateHttpClient(): HttpClient {
     val version = NSBundle.mainBundle.objectForInfoDictionaryKey("CFBundleShortVersionString") as String
     return HttpClient(Ios) {
         install(UserAgent) {
-            agent = "official-app-2019/$version"
+            agent = "official-app-2019/$version gzip"
         }
         install(JsonFeature) {
             serializer = KotlinxSerializer(JSON.nonstrict)

--- a/data/api-impl/src/main/java/io/github/droidkaigi/confsched2019/data/api/UserAgentInterceptor.kt
+++ b/data/api-impl/src/main/java/io/github/droidkaigi/confsched2019/data/api/UserAgentInterceptor.kt
@@ -7,7 +7,7 @@ import okhttp3.Response
 internal class UserAgentInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         return chain.proceed(chain.request().newBuilder().apply {
-            addHeader("User-Agent", "official-app-2019/${BuildConfig.VERSION_CODE}")
+            addHeader("User-Agent", "official-app-2019/${BuildConfig.VERSION_CODE} gzip")
         }.build())
     }
 }


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
I think using HTTP with gzip compression is a good way to reduce network traffic.

OkHttp adds `Content-Encoding: gzip` header automatically. However, to enable gzip in GoogleAppEngine, [it must also be included in User-Agent.](https://cloud.google.com/appengine/docs/standard/go/how-requests-are-handled#response_compression)

## Links
- https://cloud.google.com/appengine/docs/standard/go/how-requests-are-handled#response_compression

## Screenshot

Before ⬇️ 
![2019-01-16 19 09 11](https://user-images.githubusercontent.com/3610682/51243140-18fd0e80-19c5-11e9-93f2-16217a178699.png) 

After ⬇️ 
![2019-01-16 19 11 10](https://user-images.githubusercontent.com/3610682/51243220-4ea1f780-19c5-11e9-955b-64c1c7595443.png)

I confirmed that the traffic of the `timetable` decreased to 1/3 by the Android Profiler.