### PR TITLE
Add error callback for iOS in common module

### DIFF
--- a/data/api-impl/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/KtorDroidKaigiApi.kt
+++ b/data/api-impl/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/KtorDroidKaigiApi.kt
@@ -33,10 +33,14 @@ open class KtorDroidKaigiApi constructor(
         return JSON.nonstrict.parse(ResponseImpl.serializer(), rawResponse)
     }
 
-    override fun getSessions(callback: (response: Response) -> Unit) {
+    override fun getSessions(callback: (response: Response) -> Unit, onError: (error: Exception) -> Unit) {
         GlobalScope.launch(requireNotNull(coroutineDispatcherForCallback)) {
-            val response = getSessions()
-            callback(response)
+            try {
+                val response = getSessions()
+                callback(response)
+            } catch (ex: Exception) {
+                onError(ex)
+            }
         }
     }
 

--- a/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/DroidKaigiApi.kt
+++ b/data/api/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/DroidKaigiApi.kt
@@ -8,7 +8,7 @@ import io.github.droidkaigi.confsched2019.data.api.response.SponsorResponse
 interface DroidKaigiApi {
     suspend fun getSessions(): Response
 
-    fun getSessions(callback: (response: Response) -> Unit)
+    fun getSessions(callback: (response: Response) -> Unit, onError: (error: Exception) -> Unit)
 
     suspend fun getSponsors(): SponsorResponse
 

--- a/frontend/ios/DroidKaigi 2019/SessionRepository.swift
+++ b/frontend/ios/DroidKaigi 2019/SessionRepository.swift
@@ -14,11 +14,13 @@ final class SessionRepository {
     
     func fetch() -> Single<SessionContents> {
         return Single<SessionContents>.create { observer -> Disposable in
-            // TODO: How can we get errors from DroidKaigiApi?
-            ApiComponentKt.generateDroidKaigiApi().getSessions() { response in
+            ApiComponentKt.generateDroidKaigiApi().getSessions(callback: { response in
                 observer(.success(ResponseToModelMapperKt.toModel(response)))
                 return KotlinUnit()
-            }
+            }, onError: { error in
+                observer(.error(NSError(domain: error.message ?? "No message", code: -1, userInfo: nil)))
+                return KotlinUnit()
+            })
             return Disposables.create()
         }
     }

--- a/frontend/ios/DroidKaigi 2019/SessionsViewController.swift
+++ b/frontend/ios/DroidKaigi 2019/SessionsViewController.swift
@@ -27,6 +27,18 @@ final class SessionsViewController: UIViewController {
             }
             .disposed(by: disposeBag)
         
+        viewModel.error
+            .bind {[weak self] (errorMessage) in
+                if let errMsg = errorMessage {
+                    let alert = UIAlertController(title: "ERROR", message: errMsg, preferredStyle: UIAlertController.Style.alert)
+                    let closeButton = UIAlertAction(title: "Close", style: UIAlertAction.Style.cancel, handler: nil)
+                    alert.addAction(closeButton)
+                    
+                    self?.present(alert, animated: true, completion: nil)
+                }
+            }
+            .disposed(by: disposeBag)
+
         self.viewModel = viewModel
     }
 }


### PR DESCRIPTION
## Issue
- close #493

## Overview (Required)
- Add ``onError`` callback to ``DroidKaigiApi.getSessions``
- Receive onError in iOS(swift) and implement display alert

## Screenshot
Before | After
:--: | :--:
N/A | <img src="https://user-images.githubusercontent.com/401369/51264155-30ee8580-19f9-11e9-8136-007d812c0639.png" width="300" style="max-width:100%;">

I'm not sure that how to raise exception in ``DroidKaigiApi.getSessions``.
I tried turn offline my iPhone but ``getSessions`` returns success(empty response).
So I change [ApiEndpoint](https://github.com/DroidKaigi/conference-app-2019/blob/a5dc5133cf1e1ad4eaad435c4816aa43a2e6cb8d/data/api-impl/src/iosMain/kotlin/io/github/droidkaigi/confsched2019/data/api/ApiEndpoint.kt#L5) to invalid url then I can confirmed call error callback. 