### PR TITLE
Remove progress indicator when toggle favorite

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
@@ -117,7 +117,6 @@ class SessionDetailFragment : DaggerFragment() {
 
         binding.sessionFavorite.setOnClickListener {
             val session = binding.session ?: return@setOnClickListener
-            progressTimeLatch.loading = true
 
             // Immediate reflection on view to avoid time lag
             binding.sessionFavorite.setImageResource(

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SessionContentsActionCreator.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SessionContentsActionCreator.kt
@@ -66,15 +66,12 @@ class SessionContentsActionCreator @Inject constructor(
     fun toggleFavorite(session: Session) {
         launch {
             try {
-                dispatcher.dispatchLoadingState(LoadingState.LOADING)
                 sessionRepository.toggleFavorite(session)
                 sessionAlarm.toggleRegister(session)
                 val sessionContents = sessionRepository.sessionContents()
                 dispatcher.dispatch(Action.SessionContentsLoaded(sessionContents))
-                dispatcher.dispatchLoadingState(LoadingState.LOADED)
             } catch (e: Exception) {
                 onError(e)
-                dispatcher.dispatchLoadingState(LoadingState.INITIALIZED)
             }
         }
     }

--- a/feature/session/src/test/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SessionContentsActionCreatorTest.kt
+++ b/feature/session/src/test/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SessionContentsActionCreatorTest.kt
@@ -70,14 +70,12 @@ class SessionContentsActionCreatorTest {
         )
 
         coVerify(ordering = Ordering.SEQUENCE) {
-            dispatcher.dispatch(Action.SessionLoadingStateChanged(LoadingState.LOADING))
             sessionRepository.toggleFavorite(firstDummySpeechSession())
             sessionAlarm.toggleRegister(firstDummySpeechSession())
             sessionRepository.sessionContents()
             dispatcher.dispatch(
                 Action.SessionContentsLoaded(dummySessionContents)
             )
-            dispatcher.dispatch(Action.SessionLoadingStateChanged(LoadingState.LOADED))
         }
     }
 }


### PR DESCRIPTION
## Issue
- close #497 

## Overview (Required)
- Remove progress indicator when toggle favorite
- Use will has no frustration when add/remove to MyPlan.
- This is not an optimistic update. Because updating the UI is done after changing the data. Updating only the UI without waiting for data changes is not undertaken since it is big change.


## Screenshot
Before | After
:--: | :--:
|![before](https://user-images.githubusercontent.com/937552/51374288-ea5a7180-1b45-11e9-8dd4-00f2045c6a3a.gif)|![after](https://user-images.githubusercontent.com/937552/51374093-3eb12180-1b45-11e9-8fe6-2804dcba0d8c.gif)|
