### PR TITLE
Session detail expand with animation

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
@@ -20,6 +20,7 @@ import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavController
+import androidx.transition.TransitionManager
 import com.soywiz.klock.DateTimeSpan
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.ViewHolder
@@ -210,6 +211,7 @@ class SessionDetailFragment : DaggerFragment() {
                 val ellipsis = getString(R.string.ellipsis_label)
                 val ellipsisColor = ContextCompat.getColor(requireContext(), R.color.colorSecondary)
                 val onClickListener = {
+                    TransitionManager.beginDelayedTransition(binding.sessionLayout)
                     val session = binding.speechSession?.desc
                     binding.sessionDescription.text = session
                     showEllipsis = !showEllipsis

--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -63,6 +63,7 @@
             >
 
             <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/session_layout"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:paddingBottom="24dp"


### PR DESCRIPTION
## Issue
- close #515

## Overview (Required)
- Session detail expand with animation by TransitionManager.beginDelayedTransition()

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1386930/51381754-57770280-1b58-11e9-9934-a99b1c9840c1.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/18392939/51395804-0fb8a100-1b81-11e9-9d3d-dc53bb9f3ad0.gif" width="300" />

