### PR TITLE
Sort sessions in search screen

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SearchFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SearchFragment.kt
@@ -112,6 +112,16 @@ class SearchFragment : DaggerFragment() {
                                 )
                             )
                     }
+                }.sortedBy { item ->
+                    when (item) {
+                        is SpeechSessionItem ->
+                            item.speechSession.title.getByLang(defaultLang())
+                                .toUpperCase()
+                        is ServiceSessionItem ->
+                            item.serviceSession.title.getByLang(defaultLang())
+                                .toUpperCase()
+                        else -> StickyHeaderItemDecoration.DEFAULT_TITLE
+                    }
                 }
             groupAdapter.update(items)
         }
@@ -272,6 +282,7 @@ class StickyHeaderItemDecoration(
     companion object {
         const val EMPTY_ID: Long = -1
         const val DEFAULT_INITIAL = "*"
+        const val DEFAULT_TITLE = "******"
     }
 }
 


### PR DESCRIPTION
## Issue
- close #528 

## Overview (Required)
- sort sessions by title

## Links
-

## Screenshot
Before | After
:--: | :--:
<img width="319" alt="2019-01-19 4 21 02" src="https://user-images.githubusercontent.com/19910245/51408344-b745cb80-1ba1-11e9-9f9d-a67dc536cdec.png">|<img width="317" alt="2019-01-19 4 23 34" src="https://user-images.githubusercontent.com/19910245/51408439-08ee5600-1ba2-11e9-9c3c-9a7e37343b3c.png">


