### PR TITLE
Fixed service sessions in search screen

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetDaySessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetDaySessionsFragment.kt
@@ -108,7 +108,8 @@ class BottomSheetDaySessionsFragment : DaggerFragment() {
                                 session,
                                 SessionPagesFragmentDirections.actionSessionToSessionDetail(
                                     session.id
-                                )
+                                ),
+                                true
                             )
                     }
                 }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetFavoriteSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetFavoriteSessionsFragment.kt
@@ -117,7 +117,8 @@ class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
                                 session,
                                 SessionPagesFragmentDirections.actionSessionToSessionDetail(
                                     session.id
-                                )
+                                ),
+                                true
                             )
                     }
                 }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SearchFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SearchFragment.kt
@@ -109,7 +109,8 @@ class SearchFragment : DaggerFragment() {
                                 session,
                                 SearchFragmentDirections.actionSearchToSessionDetail(
                                     session.id
-                                )
+                                ),
+                                false
                             )
                     }
                 }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/ServiceSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/ServiceSessionItem.kt
@@ -14,7 +14,7 @@ import io.github.droidkaigi.confsched2019.session.ui.actioncreator.SessionConten
 class ServiceSessionItem @AssistedInject constructor(
     @Assisted override val session: Session.ServiceSession,
     @Assisted val navDirections: NavDirections,
-    @Assisted val addPaddingForTime: Boolean,
+    @Assisted val hasStartPadding: Boolean,
     navController: NavController,
     sessionContentsActionCreator: SessionContentsActionCreator
 ) : BindableItem<ItemServiceSessionBinding>(
@@ -27,7 +27,7 @@ class ServiceSessionItem @AssistedInject constructor(
         fun create(
             session: Session.ServiceSession,
             navDirections: NavDirections,
-            addPaddingForTime: Boolean
+            hasStartPadding: Boolean
         ): ServiceSessionItem
     }
 
@@ -49,7 +49,7 @@ class ServiceSessionItem @AssistedInject constructor(
                 root.setOnClickListener(null)
                 root.isClickable = false
             }
-            addPaddingForTime = this@ServiceSessionItem.addPaddingForTime
+            hasStartPadding = this@ServiceSessionItem.hasStartPadding
             session = serviceSession
             lang = defaultLang()
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/ServiceSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/ServiceSessionItem.kt
@@ -14,6 +14,7 @@ import io.github.droidkaigi.confsched2019.session.ui.actioncreator.SessionConten
 class ServiceSessionItem @AssistedInject constructor(
     @Assisted override val session: Session.ServiceSession,
     @Assisted val navDirections: NavDirections,
+    @Assisted val addPaddingForTime: Boolean,
     navController: NavController,
     sessionContentsActionCreator: SessionContentsActionCreator
 ) : BindableItem<ItemServiceSessionBinding>(
@@ -25,7 +26,8 @@ class ServiceSessionItem @AssistedInject constructor(
     interface Factory {
         fun create(
             session: Session.ServiceSession,
-            navDirections: NavDirections
+            navDirections: NavDirections,
+            addPaddingForTime: Boolean
         ): ServiceSessionItem
     }
 
@@ -47,6 +49,7 @@ class ServiceSessionItem @AssistedInject constructor(
                 root.setOnClickListener(null)
                 root.isClickable = false
             }
+            addPaddingForTime = this@ServiceSessionItem.addPaddingForTime
             session = serviceSession
             lang = defaultLang()
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
@@ -31,7 +31,7 @@ import kotlin.math.max
 class SpeechSessionItem @AssistedInject constructor(
     @Assisted override val session: Session.SpeechSession,
     @Assisted val navDirections: NavDirections,
-    @Assisted val addPaddingForTime: Boolean,
+    @Assisted val hasStartPadding: Boolean,
     val navController: NavController,
     val sessionContentsActionCreator: SessionContentsActionCreator
 ) : BindableItem<ItemSessionBinding>(
@@ -44,7 +44,7 @@ class SpeechSessionItem @AssistedInject constructor(
         fun create(
             session: Session.SpeechSession,
             navDirections: NavDirections,
-            addPaddingForTime: Boolean
+            hasStartPadding: Boolean
         ): SpeechSessionItem
     }
 
@@ -59,7 +59,7 @@ class SpeechSessionItem @AssistedInject constructor(
             }
             session = speechSession
             lang = defaultLang()
-            addPaddingForTime = this@SpeechSessionItem.addPaddingForTime
+            hasStartPadding = this@SpeechSessionItem.hasStartPadding
             favorite.setOnClickListener {
                 sessionContentsActionCreator.toggleFavorite(speechSession)
             }

--- a/feature/session/src/main/res/layout/item_service_session.xml
+++ b/feature/session/src/main/res/layout/item_service_session.xml
@@ -20,6 +20,11 @@
             name="lang"
             type="io.github.droidkaigi.confsched2019.model.Lang"
             />
+
+        <variable
+            name="addPaddingForTime"
+            type="boolean"
+            />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -29,7 +34,7 @@
         android:paddingTop="@dimen/session_item_top_padding"
         android:paddingBottom="@dimen/session_item_bottom_padding"
         android:paddingEnd="0dp"
-        android:paddingStart="@dimen/session_bottom_sheet_left_time_space"
+        android:paddingStart="@{addPaddingForTime ? @dimen/session_bottom_sheet_left_time_space : 0}"
         >
 
         <TextView

--- a/feature/session/src/main/res/layout/item_service_session.xml
+++ b/feature/session/src/main/res/layout/item_service_session.xml
@@ -9,8 +9,6 @@
 
         <import type="io.github.droidkaigi.confsched2019.model.SessionType"/>
 
-        <import type="android.view.View"/>
-
         <variable
             name="session"
             type="io.github.droidkaigi.confsched2019.model.Session.ServiceSession"
@@ -22,7 +20,7 @@
             />
 
         <variable
-            name="addPaddingForTime"
+            name="hasStartPadding"
             type="boolean"
             />
     </data>
@@ -34,7 +32,7 @@
         android:paddingTop="@dimen/session_item_top_padding"
         android:paddingBottom="@dimen/session_item_bottom_padding"
         android:paddingEnd="0dp"
-        android:paddingStart="@{addPaddingForTime ? @dimen/session_bottom_sheet_left_time_space : 0}"
+        android:paddingStart="@{hasStartPadding ? @dimen/session_bottom_sheet_left_time_space : 0}"
         >
 
         <TextView

--- a/feature/session/src/main/res/layout/item_session.xml
+++ b/feature/session/src/main/res/layout/item_session.xml
@@ -18,7 +18,7 @@
             />
 
         <variable
-            name="addPaddingForTime"
+            name="hasStartPadding"
             type="boolean"
             />
     </data>
@@ -29,7 +29,7 @@
         android:foreground="?android:attr/selectableItemBackground"
         android:paddingBottom="@dimen/session_item_bottom_padding"
         android:paddingEnd="0dp"
-        android:paddingStart="@{addPaddingForTime ? @dimen/session_bottom_sheet_left_time_space : 0}"
+        android:paddingStart="@{hasStartPadding ? @dimen/session_bottom_sheet_left_time_space : 0}"
         android:paddingTop="@dimen/session_item_top_padding"
         >
 


### PR DESCRIPTION
## Issue
- close #526 

## Overview (Required)
- Removed left space of service sessions in search screen.
Implemented in the same way as `SpeechSessionItem`.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13705006/51420919-7fa74580-1bda-11e9-9c36-685c9bf2c543.png" width="300" /> | <img src="https://user-images.githubusercontent.com/13705006/51420989-6ce14080-1bdb-11e9-8e84-4ac474a03aba.png" width="300" />
