### PR TITLE
Avoid adding project dependencies without using the project name

### DIFF
--- a/frontend/ios-combined/build.gradle
+++ b/frontend/ios-combined/build.gradle
@@ -31,18 +31,18 @@ kotlin {
                 projectsList.forEach {
                     project(it).configurations.all { c ->
                         if (c.name == "commonMainApi") {
-                            c.dependencies.all {
+                            c.dependencies.all { dep ->
                                 // note: Avoid dependencies for this project's modules like a `api project(":model")`.
                                 //       Already these classes are included via `srcDir`,
                                 //       so adding dependencies for projects causes compile error by double declaration.
-                                if (!it.group.startsWith("conference-app-2019")) {
-                                    api it
+                                if (!(dep instanceof ProjectDependency)) {
+                                    api dep
                                 }
                             }
                         } else if (c.name == "commonMainImplementation") {
-                            c.dependencies.all {
-                                if (!it.group.startsWith("conference-app-2019")) {
-                                    implementation it
+                            c.dependencies.all { dep ->
+                                if (!(dep instanceof ProjectDependency)) {
+                                    implementation dep
                                 }
                             }
                         }
@@ -59,15 +59,15 @@ kotlin {
                 projectsList.forEach {
                     project(it).configurations.all { c ->
                         if (c.name == "iOSMainApi") {
-                            c.dependencies.all {
-                                if (!it.group.startsWith("conference-app-2019")) {
-                                    api it
+                            c.dependencies.all { dep ->
+                                if (!(dep instanceof ProjectDependency)) {
+                                    api dep
                                 }
                             }
                         } else if (c.name == "iOSMainImplementation") {
-                            c.dependencies.all {
-                                if (!it.group.startsWith("conference-app-2019")) {
-                                    implementation it
+                            c.dependencies.all { dep ->
+                                if (!(dep instanceof ProjectDependency)) {
+                                    implementation dep
                                 }
                             }
                         }


### PR DESCRIPTION
## Issue
- Related #495

## Overview (Required)
- As the comment in the code described, project dependencies shouldn't be added twice. (Kotlin multi-platform plugin did it once. see https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinMultiplatformPlugin.kt#L72 )
- group name depends on the root directory name of the project so ios build failed if we use the directory name except `conference-app-2019`

## Links
- https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinMultiplatformPlugin.kt#L72
