### PR TITLE
Show original message if toggle session favarite fail

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SessionContentsActionCreator.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SessionContentsActionCreator.kt
@@ -6,8 +6,10 @@ import io.github.droidkaigi.confsched2019.data.repository.SessionRepository
 import io.github.droidkaigi.confsched2019.di.PageScope
 import io.github.droidkaigi.confsched2019.dispatcher.Dispatcher
 import io.github.droidkaigi.confsched2019.ext.android.coroutineScope
+import io.github.droidkaigi.confsched2019.model.ErrorMessage
 import io.github.droidkaigi.confsched2019.model.LoadingState
 import io.github.droidkaigi.confsched2019.model.Session
+import io.github.droidkaigi.confsched2019.session.R
 import io.github.droidkaigi.confsched2019.system.actioncreator.ErrorHandler
 import io.github.droidkaigi.confsched2019.util.SessionAlarm
 import kotlinx.coroutines.CoroutineScope
@@ -71,7 +73,9 @@ class SessionContentsActionCreator @Inject constructor(
                 val sessionContents = sessionRepository.sessionContents()
                 dispatcher.dispatch(Action.SessionContentsLoaded(sessionContents))
             } catch (e: Exception) {
-                onError(e)
+                dispatcher.dispatch(
+                    Action.Error(ErrorMessage.Companion.of(R.string.session_favorite_connection_error, e))
+                )
             }
         }
     }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SessionContentsActionCreator.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SessionContentsActionCreator.kt
@@ -74,7 +74,9 @@ class SessionContentsActionCreator @Inject constructor(
                 dispatcher.dispatch(Action.SessionContentsLoaded(sessionContents))
             } catch (e: Exception) {
                 dispatcher.dispatch(
-                    Action.Error(ErrorMessage.Companion.of(R.string.session_favorite_connection_error, e))
+                    Action.Error(ErrorMessage.Companion.of(
+                        R.string.session_favorite_connection_error, e)
+                    )
                 )
             }
         }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SessionContentsActionCreator.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SessionContentsActionCreator.kt
@@ -74,7 +74,7 @@ class SessionContentsActionCreator @Inject constructor(
                 dispatcher.dispatch(Action.SessionContentsLoaded(sessionContents))
             } catch (e: Exception) {
                 dispatcher.dispatch(
-                    Action.Error(ErrorMessage.Companion.of(
+                    Action.Error(ErrorMessage.of(
                         R.string.session_favorite_connection_error, e)
                     )
                 )

--- a/feature/session/src/main/res/values-ja/strings.xml
+++ b/feature/session/src/main/res/values-ja/strings.xml
@@ -16,4 +16,5 @@
     <string name="session_simultaneous_interpretation">同時通訳</string>
     <string name="session_for_beginners">初心者向け</string>
     <string name="session_favorite_empty">お気に入りのセッションを登録すると\nあなた専用のプランを作ることが\nできます。</string>
+    <string name="session_favorite_connection_error">お気に入りに失敗しました。</string>
 </resources>

--- a/feature/session/src/main/res/values-ja/strings.xml
+++ b/feature/session/src/main/res/values-ja/strings.xml
@@ -16,5 +16,5 @@
     <string name="session_simultaneous_interpretation">同時通訳</string>
     <string name="session_for_beginners">初心者向け</string>
     <string name="session_favorite_empty">お気に入りのセッションを登録すると\nあなた専用のプランを作ることが\nできます。</string>
-    <string name="session_favorite_connection_error">お気に入りに失敗しました。</string>
+    <string name="session_favorite_connection_error">お気に入りに失敗しました。後ほど再度お試しください。</string>
 </resources>

--- a/feature/session/src/main/res/values/strings.xml
+++ b/feature/session/src/main/res/values/strings.xml
@@ -32,4 +32,5 @@
     <string name="session_for_beginners">For Beginners</string>
     <string name="session_bottom_appbar_behavior" translatable="false">io.github.droidkaigi.confsched2019.session.ui.widget.SessionBottomAppBarBehavior</string>
     <string name="session_favorite_empty">Add sessions to your plan\nby tapping the bookmark button.</string>
+    <string name="session_favorite_connection_error">Could not register as a favorite.</string>
 </resources>

--- a/feature/session/src/main/res/values/strings.xml
+++ b/feature/session/src/main/res/values/strings.xml
@@ -32,5 +32,5 @@
     <string name="session_for_beginners">For Beginners</string>
     <string name="session_bottom_appbar_behavior" translatable="false">io.github.droidkaigi.confsched2019.session.ui.widget.SessionBottomAppBarBehavior</string>
     <string name="session_favorite_empty">Add sessions to your plan\nby tapping the bookmark button.</string>
-    <string name="session_favorite_connection_error">Could not register as a favorite.</string>
+    <string name="session_favorite_connection_error">Could not register as a favorite. Retry later.</string>
 </resources>


### PR DESCRIPTION
## Issue
- close #513

## Overview (Required)
- Show original message if toggle session favarite fail
- Network error message is already show on SnackBar when failed favorite. So I just implemented a original message for failed favorite.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1439687/51426499-1998dd80-1c2f-11e9-83fe-e340fbbc95a3.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/1439687/51426529-6e3c5880-1c2f-11e9-813f-b79f51d616f6.gif" width="300" />