### PR TITLE
Add commit hash to about screen

### DIFF
--- a/feature/about/build.gradle
+++ b/feature/about/build.gradle
@@ -10,7 +10,7 @@ apply from: rootProject.file('gradle/android.gradle')
 android.dataBinding.enabled = true
 android {
     defaultConfig {
-        resValue "string", "version_name", Versions.androidVersionName
+        resValue "string", "version_name_with_commit_hash", "${Versions.androidVersionName} (${commitHash})"
     }
 }
 
@@ -53,4 +53,8 @@ dependencies {
     testImplementation Dep.Test.junit
     androidTestImplementation Dep.Test.testRunner
     androidTestImplementation Dep.Test.espressoCore
+}
+
+static def getCommitHash() {
+    'git rev-parse --short HEAD'.execute().text.trim()
 }

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2019/about/ui/item/AboutSection.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2019/about/ui/item/AboutSection.kt
@@ -46,7 +46,7 @@ class AboutSection @Inject constructor(
                 },
                 AboutItem(
                     name = R.string.about_app_version,
-                    description = R.string.version_name,
+                    description = R.string.version_name_with_commit_hash,
                     isLektonCheckText = true
                 )
             )


### PR DESCRIPTION
## Issue
- close #554

## Overview (Required)
- Get current commit hash by using `git rev-parse --short HEAD` on build time, and use it on about screen.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/2571506/51437911-1c0b3e00-1ce8-11e9-9312-b1907b045927.png" width="300" /> | <img src="https://user-images.githubusercontent.com/2571506/51437916-35ac8580-1ce8-11e9-87d3-28926a718af3.png" width="300" />
