### PR TITLE
Add margin to speakers list

### DIFF
--- a/feature/session/src/main/res/layout/layout_speaker.xml
+++ b/feature/session/src/main/res/layout/layout_speaker.xml
@@ -10,6 +10,7 @@
         android:id="@+id/speaker"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="2dp"
         android:drawablePadding="4dp"
         android:textAppearance="?textAppearanceCaption"
         tools:text="taka"


### PR DESCRIPTION
## Issue
- close #563

## Overview (Required)
- Added margin at bottom of each speaker.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/457327/51439630-7dd7a200-1d00-11e9-9eda-b0de55282b4f.png" width="300" /> | <img src="https://user-images.githubusercontent.com/457327/51439632-829c5600-1d00-11e9-90f7-552c56417e36.png" width="300" />
