### PR TITLE
Add empty Fragments and layouts for tabular form sessions

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/TabularFormSessionPageFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/TabularFormSessionPageFragment.kt
@@ -1,0 +1,54 @@
+package io.github.droidkaigi.confsched2019.session.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.lifecycle.Lifecycle
+import dagger.Module
+import dagger.Provides
+import io.github.droidkaigi.confsched2019.session.R
+import io.github.droidkaigi.confsched2019.session.databinding.FragmentTabularFormSessionPageBinding
+import io.github.droidkaigi.confsched2019.session.di.SessionPageScope
+import io.github.droidkaigi.confsched2019.session.ui.widget.DaggerFragment
+
+class TabularFormSessionPageFragment : DaggerFragment() {
+
+    private lateinit var binding: FragmentTabularFormSessionPageBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = DataBindingUtil.inflate(
+            inflater,
+            R.layout.fragment_tabular_form_session_page,
+            container,
+            false
+        )
+        return binding.root
+    }
+
+    companion object {
+        fun newInstance(): TabularFormSessionPageFragment {
+            return TabularFormSessionPageFragment()
+        }
+    }
+}
+
+@Module
+abstract class TabularFormSessionPageFragmentModule {
+
+    @Module
+    companion object {
+        @JvmStatic @Provides
+        @SessionPageScope
+        fun providesLifecycle(
+            tabularFromSessionPageFragment: TabularFormSessionPageFragment
+        ): Lifecycle {
+            return tabularFromSessionPageFragment.viewLifecycleOwner.lifecycle
+        }
+    }
+}

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/TabularFormSessionPagesFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/TabularFormSessionPagesFragment.kt
@@ -1,0 +1,86 @@
+package io.github.droidkaigi.confsched2019.session.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentStatePagerAdapter
+import androidx.lifecycle.Lifecycle
+import androidx.viewpager.widget.ViewPager
+import com.soywiz.klock.DateTime
+import com.soywiz.klock.hours
+import dagger.Module
+import dagger.Provides
+import dagger.android.ContributesAndroidInjector
+import io.github.droidkaigi.confsched2019.di.PageScope
+import io.github.droidkaigi.confsched2019.model.SessionPage
+import io.github.droidkaigi.confsched2019.session.R
+import io.github.droidkaigi.confsched2019.session.ui.widget.DaggerFragment
+import io.github.droidkaigi.confsched2019.session.databinding.FragmentTabularFormSessionPagesBinding
+import io.github.droidkaigi.confsched2019.session.di.SessionPageScope
+import io.github.droidkaigi.confsched2019.session.ui.store.SessionContentsStore
+import javax.inject.Inject
+
+class TabularFormSessionPagesFragment : DaggerFragment() {
+
+    private lateinit var binding: FragmentTabularFormSessionPagesBinding
+    @Inject lateinit var sessionContentsStore: SessionContentsStore
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = DataBindingUtil.inflate(
+            inflater,
+            R.layout.fragment_tabular_form_session_pages,
+            container,
+            false
+        )
+        return binding.root
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        setupSessionPager()
+    }
+
+    private fun setupSessionPager() {
+        binding.tabularFormSessionsTabLayout.setupWithViewPager(binding.tabularFormSessionsViewpager)
+        binding.tabularFormSessionsViewpager.adapter = object : FragmentStatePagerAdapter(
+            childFragmentManager
+        ) {
+
+            private val days = listOf(SessionPage.pageOfDay(1), SessionPage.pageOfDay(2))
+
+            override fun getItem(position: Int): Fragment {
+                return TabularFormSessionPageFragment.newInstance()
+            }
+
+            override fun getPageTitle(position: Int) = days[position].title
+            override fun getCount(): Int = days.size
+        }
+    }
+}
+
+@Module
+abstract class TabularFromSessionPagesFragmentModule {
+
+    @SessionPageScope
+    @ContributesAndroidInjector(modules = [TabularFormSessionPageFragmentModule::class])
+    abstract fun contributeTabularFormSessionPageFragment(): TabularFormSessionPageFragment
+
+    @Module
+    companion object {
+        @JvmStatic @Provides
+        @PageScope
+        fun providesLifecycle(
+            tabularFromSessionPagesFragment: TabularFormSessionPagesFragment
+        ): Lifecycle {
+            return tabularFromSessionPagesFragment.viewLifecycleOwner.lifecycle
+        }
+    }
+}

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/TabularFormSessionPagesFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/TabularFormSessionPagesFragment.kt
@@ -4,14 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentStatePagerAdapter
 import androidx.lifecycle.Lifecycle
-import androidx.viewpager.widget.ViewPager
-import com.soywiz.klock.DateTime
-import com.soywiz.klock.hours
 import dagger.Module
 import dagger.Provides
 import dagger.android.ContributesAndroidInjector
@@ -49,7 +45,9 @@ class TabularFormSessionPagesFragment : DaggerFragment() {
     }
 
     private fun setupSessionPager() {
-        binding.tabularFormSessionsTabLayout.setupWithViewPager(binding.tabularFormSessionsViewpager)
+        binding.tabularFormSessionsTabLayout.setupWithViewPager(
+            binding.tabularFormSessionsViewpager
+        )
         binding.tabularFormSessionsViewpager.adapter = object : FragmentStatePagerAdapter(
             childFragmentManager
         ) {

--- a/feature/session/src/main/res/drawable/ic_table_chart_24dp.xml
+++ b/feature/session/src/main/res/drawable/ic_table_chart_24dp.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:pathData="M0,0 L24,0 L24,24 L0,24 L0,0 Z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M10,10.02 L15,10.02 L15,21 L10,21 Z M17,21 L20,21 C21.1,21,22,20.1,22,19 L22,10 L17,10 L17,21 Z M20,3 L5,3 C3.9,3,3,3.9,3,5 L3,8 L22,8 L22,5 C22,3.9,21.1,3,20,3 Z M3,19 C3,20.1,3.9,21,5,21 L8,21 L8,10 L3,10 L3,19 Z" />
+</vector>
+

--- a/feature/session/src/main/res/layout/fragment_tabular_form_session_page.xml
+++ b/feature/session/src/main/res/layout/fragment_tabular_form_session_page.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        >
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            >
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/feature/session/src/main/res/layout/fragment_tabular_form_session_page.xml
+++ b/feature/session/src/main/res/layout/fragment_tabular_form_session_page.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        >
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    >
 
     <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            >
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        >
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/feature/session/src/main/res/layout/fragment_tabular_form_session_pages.xml
+++ b/feature/session/src/main/res/layout/fragment_tabular_form_session_pages.xml
@@ -1,47 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        >
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    >
 
     <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            tools:context="io.github.droidkaigi.confsched2019.session.ui.TabularFromSessionPagesFragment"
-            >
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context="io.github.droidkaigi.confsched2019.session.ui.TabularFromSessionPagesFragment"
+        >
 
         <com.google.android.material.tabs.TabLayout
-                android:id="@+id/tabular_form_sessions_tab_layout"
-                android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                android:tabStripEnabled="false"
-                android:textSize="12sp"
-                android:textColor="#99000000"
-                android:elevation="3dp"
-                app:tabGravity="fill"
-                app:tabIndicatorHeight="2dp"
-                app:tabIndicatorColor="@color/colorPrimary"
-                app:tabSelectedTextColor="@color/colorPrimary"
-                app:tabTextAppearance="@style/TextAppearance.App.Body1"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toTopOf="@+id/tabular_form_sessions_viewpager"
-                />
+            android:id="@+id/tabular_form_sessions_tab_layout"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:tabStripEnabled="false"
+            android:textSize="12sp"
+            android:textColor="#99000000"
+            android:elevation="3dp"
+            app:tabGravity="fill"
+            app:tabIndicatorHeight="2dp"
+            app:tabIndicatorColor="@color/colorPrimary"
+            app:tabSelectedTextColor="@color/colorPrimary"
+            app:tabTextAppearance="@style/TextAppearance.App.Body1"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/tabular_form_sessions_viewpager"
+            />
 
         <androidx.viewpager.widget.ViewPager
-                android:id="@+id/tabular_form_sessions_viewpager"
-                android:layout_width="match_parent"
-                android:layout_height="0dp"
-                app:layout_constraintTop_toBottomOf="@+id/tabular_form_sessions_tab_layout"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_behavior="@string/appbar_scrolling_view_behavior"
-                />
+            android:id="@+id/tabular_form_sessions_viewpager"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@+id/tabular_form_sessions_tab_layout"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            />
 
         <ProgressBar
-                android:id="@+id/progress_bar"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                />
+            android:id="@+id/progress_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/feature/session/src/main/res/layout/fragment_tabular_form_session_pages.xml
+++ b/feature/session/src/main/res/layout/fragment_tabular_form_session_pages.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        >
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            tools:context="io.github.droidkaigi.confsched2019.session.ui.TabularFromSessionPagesFragment"
+            >
+
+        <com.google.android.material.tabs.TabLayout
+                android:id="@+id/tabular_form_sessions_tab_layout"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:tabStripEnabled="false"
+                android:textSize="12sp"
+                android:textColor="#99000000"
+                android:elevation="3dp"
+                app:tabGravity="fill"
+                app:tabIndicatorHeight="2dp"
+                app:tabIndicatorColor="@color/colorPrimary"
+                app:tabSelectedTextColor="@color/colorPrimary"
+                app:tabTextAppearance="@style/TextAppearance.App.Body1"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toTopOf="@+id/tabular_form_sessions_viewpager"
+                />
+
+        <androidx.viewpager.widget.ViewPager
+                android:id="@+id/tabular_form_sessions_viewpager"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                app:layout_constraintTop_toBottomOf="@+id/tabular_form_sessions_tab_layout"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_behavior="@string/appbar_scrolling_view_behavior"
+                />
+
+        <ProgressBar
+                android:id="@+id/progress_bar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/feature/session/src/main/res/menu/menu_toolbar.xml
+++ b/feature/session/src/main/res/menu/menu_toolbar.xml
@@ -3,6 +3,15 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     >
+
+    <item
+        android:id="@id/tabular_form"
+        android:icon="@drawable/ic_table_chart_24dp"
+        android:title="@string/tabular_form_label"
+        app:iconTint="@color/white"
+        app:showAsAction="ifRoom"
+        />
+
     <item
         android:id="@id/search"
         android:icon="@drawable/ic_search_black_24dp"

--- a/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/MainActivity.kt
+++ b/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/MainActivity.kt
@@ -45,6 +45,8 @@ import io.github.droidkaigi.confsched2019.session.ui.SessionPagesFragment
 import io.github.droidkaigi.confsched2019.session.ui.SessionPagesFragmentModule
 import io.github.droidkaigi.confsched2019.session.ui.SpeakerFragment
 import io.github.droidkaigi.confsched2019.session.ui.SpeakerFragmentModule
+import io.github.droidkaigi.confsched2019.session.ui.TabularFormSessionPagesFragment
+import io.github.droidkaigi.confsched2019.session.ui.TabularFromSessionPagesFragmentModule
 import io.github.droidkaigi.confsched2019.sponsor.ui.SponsorFragment
 import io.github.droidkaigi.confsched2019.sponsor.ui.SponsorFragmentModule
 import io.github.droidkaigi.confsched2019.survey.ui.SessionSurveyFragment
@@ -200,6 +202,12 @@ abstract class MainActivityModule {
         modules = [SearchFragmentModule::class, SessionAssistedInjectModule::class]
     )
     abstract fun contributeSearchFragment(): SearchFragment
+
+    @PageScope
+    @ContributesAndroidInjector(
+        modules = [TabularFromSessionPagesFragmentModule::class, SessionAssistedInjectModule::class]
+    )
+    abstract fun contributeTabularFormSessionPagesFragment(): TabularFormSessionPagesFragment
 
     @PageScope
     @ContributesAndroidInjector(

--- a/frontendcomponent/androidcomponent/src/main/res/navigation/navigation.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/navigation/navigation.xml
@@ -75,6 +75,12 @@
             />
     </fragment>
     <fragment
+        android:id="@+id/tabular_form"
+        android:name="io.github.droidkaigi.confsched2019.session.ui.TabularFormSessionPagesFragment"
+        android:label="@string/tabular_form_label"
+        >
+    </fragment>
+    <fragment
         android:id="@+id/speaker"
         android:name="io.github.droidkaigi.confsched2019.session.ui.SpeakerFragment"
         >

--- a/frontendcomponent/androidcomponent/src/main/res/values-ja/strings.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values-ja/strings.xml
@@ -14,4 +14,5 @@
     <string name="notification_title_session_start">マイセッション開始のお知らせ</string>
     <string name="notification_message_session_title">%1$s がもうすぐ始まります。</string>
     <string name="notification_message_session_start_time">%1$s ~ %2$s @ %3$s</string>
+    <string name="tabular_form_label">タイムテーブル</string>
 </resources>

--- a/frontendcomponent/androidcomponent/src/main/res/values/strings.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values/strings.xml
@@ -28,4 +28,6 @@
     <string name="notification_title_session_start">Notice of favorite session start</string>
     <string name="notification_message_session_title">%1$s will start soon</string>
     <string name="notification_message_session_start_time">%1$s to %2$s @ %3$s</string>
+    <!-- Tabular Form -->
+    <string name="tabular_form_label">Timetable</string>
 </resources>


### PR DESCRIPTION
## Issue
- close #518 

## Overview (Required)
- Add empty Fragments and layouts for tabular form sessions
- I want you to review about names of Fragments and navigation label
- I added newInstance() method on `TabularFormSessionPageFragment` because I think it's gonna get some arguments from safeargs. If it's not necessary, I will delete it.
- I use `SessionPageScope` to inject `TabularFormSessionPageFragment` because I think it has same scope as `SessionPageFragment`.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/6965122/51440594-145d9080-1d0c-11e9-874e-ad37674adfae.png" width="300" /> | <img src="https://user-images.githubusercontent.com/6965122/51440585-0a3b9200-1d0c-11e9-87d0-d9d1b8af374e.png" width="300" />
