### PR TITLE
Add ripple effect to About items

### DIFF
--- a/feature/about/src/main/res/layout/item_about.xml
+++ b/feature/about/src/main/res/layout/item_about.xml
@@ -24,6 +24,7 @@
         android:layout_height="60dp"
         android:layout_marginEnd="16dp"
         android:layout_marginStart="16dp"
+        android:background="?attr/selectableItemBackground"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
## Overview (Required)
- Added a touch feedback when user taps on items on the About page.


## Screenshot
![device-2019-01-20-185028](https://user-images.githubusercontent.com/3074663/51446749-49ee8380-1ce4-11e9-9dd7-00a19eac71dd.png)

