### PR TITLE
（提案）ActivityのViewModelのライフサイクルを用いてCoroutineのJobを管理する

### DIFF
--- a/feature/announcement/src/main/java/io/github/droidkaigi/confsched2019/announcement/ui/actioncreator/AnnouncementActionCreator.kt
+++ b/feature/announcement/src/main/java/io/github/droidkaigi/confsched2019/announcement/ui/actioncreator/AnnouncementActionCreator.kt
@@ -3,11 +3,12 @@ package io.github.droidkaigi.confsched2019.announcement.ui.actioncreator
 import androidx.lifecycle.Lifecycle
 import io.github.droidkaigi.confsched2019.action.Action
 import io.github.droidkaigi.confsched2019.data.repository.AnnouncementRepository
-import io.github.droidkaigi.confsched2019.di.PageScope
 import io.github.droidkaigi.confsched2019.dispatcher.Dispatcher
 import io.github.droidkaigi.confsched2019.ext.android.coroutineScope
 import io.github.droidkaigi.confsched2019.model.LoadingState
 import io.github.droidkaigi.confsched2019.system.actioncreator.ErrorHandler
+import io.github.droidkaigi.confsched2019.util.ScreenLifecycle
+import io.github.droidkaigi.confsched2019.util.coroutineScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -15,8 +16,8 @@ import javax.inject.Inject
 class AnnouncementActionCreator @Inject constructor(
     override val dispatcher: Dispatcher,
     private val announcementRepository: AnnouncementRepository,
-    @PageScope private val lifecycle: Lifecycle
-) : CoroutineScope by lifecycle.coroutineScope,
+    private val screenLifecycle: ScreenLifecycle
+) : CoroutineScope by screenLifecycle.coroutineScope,
     ErrorHandler {
 
     fun load() = launch {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SearchActionCreator.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SearchActionCreator.kt
@@ -1,21 +1,21 @@
 package io.github.droidkaigi.confsched2019.session.ui.actioncreator
 
-import androidx.lifecycle.Lifecycle
 import io.github.droidkaigi.confsched2019.action.Action
 import io.github.droidkaigi.confsched2019.di.PageScope
 import io.github.droidkaigi.confsched2019.dispatcher.Dispatcher
-import io.github.droidkaigi.confsched2019.ext.android.coroutineScope
 import io.github.droidkaigi.confsched2019.model.SearchResult
 import io.github.droidkaigi.confsched2019.model.SessionContents
 import io.github.droidkaigi.confsched2019.system.actioncreator.ErrorHandler
+import io.github.droidkaigi.confsched2019.util.ScreenLifecycle
+import io.github.droidkaigi.confsched2019.util.coroutineScope
 import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
 
 @PageScope
 class SearchActionCreator @Inject constructor(
     override val dispatcher: Dispatcher,
-    @PageScope private val lifecycle: Lifecycle
-) : CoroutineScope by lifecycle.coroutineScope,
+    private val screenLifecycle: ScreenLifecycle
+) : CoroutineScope by screenLifecycle.coroutineScope,
     ErrorHandler {
     fun search(query: String?, sessionContents: SessionContents) {
         // if we do not have query, we should show speakers and sessions

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SessionContentsActionCreator.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SessionContentsActionCreator.kt
@@ -11,7 +11,9 @@ import io.github.droidkaigi.confsched2019.model.LoadingState
 import io.github.droidkaigi.confsched2019.model.Session
 import io.github.droidkaigi.confsched2019.session.R
 import io.github.droidkaigi.confsched2019.system.actioncreator.ErrorHandler
+import io.github.droidkaigi.confsched2019.util.ScreenLifecycle
 import io.github.droidkaigi.confsched2019.util.SessionAlarm
+import io.github.droidkaigi.confsched2019.util.coroutineScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -22,9 +24,9 @@ import javax.inject.Inject
 class SessionContentsActionCreator @Inject constructor(
     override val dispatcher: Dispatcher,
     private val sessionRepository: SessionRepository,
-    @PageScope private val lifecycle: Lifecycle,
+    private val screenLifecycle: ScreenLifecycle,
     private val sessionAlarm: SessionAlarm
-) : CoroutineScope by lifecycle.coroutineScope,
+) : CoroutineScope by screenLifecycle.coroutineScope,
     ErrorHandler {
     fun refresh() = launch {
         try {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SessionPagesActionCreator.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/actioncreator/SessionPagesActionCreator.kt
@@ -13,14 +13,16 @@ import io.github.droidkaigi.confsched2019.model.Room
 import io.github.droidkaigi.confsched2019.model.Session
 import io.github.droidkaigi.confsched2019.model.SessionPage
 import io.github.droidkaigi.confsched2019.system.actioncreator.ErrorHandler
+import io.github.droidkaigi.confsched2019.util.ScreenLifecycle
+import io.github.droidkaigi.confsched2019.util.coroutineScope
 import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
 
 @PageScope
 class SessionPagesActionCreator @Inject constructor(
     override val dispatcher: Dispatcher,
-    @PageScope private val lifecycle: Lifecycle
-) : CoroutineScope by lifecycle.coroutineScope,
+    private val screenLifecycle: ScreenLifecycle
+) : CoroutineScope by screenLifecycle.coroutineScope,
     ErrorHandler {
     fun load(sessions: List<Session>) {
         dispatcher.launchAndDispatch(Action.SessionsLoaded(sessions))

--- a/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2019/sponsor/ui/actioncreator/SponsorActionCreator.kt
+++ b/feature/sponsor/src/main/java/io/github/droidkaigi/confsched2019/sponsor/ui/actioncreator/SponsorActionCreator.kt
@@ -2,12 +2,13 @@ package io.github.droidkaigi.confsched2019.sponsor.ui.actioncreator
 
 import androidx.lifecycle.Lifecycle
 import io.github.droidkaigi.confsched2019.action.Action
-import io.github.droidkaigi.confsched2019.di.PageScope
 import io.github.droidkaigi.confsched2019.dispatcher.Dispatcher
 import io.github.droidkaigi.confsched2019.ext.android.coroutineScope
 import io.github.droidkaigi.confsched2019.model.LoadingState
 import io.github.droidkaigi.confsched2019.system.actioncreator.ErrorHandler
 import io.github.droidkaigi.confsched2019.data.repository.SponsorRepository
+import io.github.droidkaigi.confsched2019.util.ScreenLifecycle
+import io.github.droidkaigi.confsched2019.util.coroutineScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -15,8 +16,8 @@ import javax.inject.Inject
 class SponsorActionCreator @Inject constructor(
     override val dispatcher: Dispatcher,
     private val sponsorRepository: SponsorRepository,
-    @PageScope private val lifecycle: Lifecycle
-) : CoroutineScope by lifecycle.coroutineScope,
+    private val screenLifecycle: ScreenLifecycle
+) : CoroutineScope by screenLifecycle.coroutineScope,
     ErrorHandler {
     fun load() = launch {
         try {

--- a/feature/staff/src/main/java/io/github/droidkaigi/confsched2019/staff/ui/actioncreator/StaffSearchActionCreator.kt
+++ b/feature/staff/src/main/java/io/github/droidkaigi/confsched2019/staff/ui/actioncreator/StaffSearchActionCreator.kt
@@ -10,6 +10,8 @@ import io.github.droidkaigi.confsched2019.model.LoadingState
 import io.github.droidkaigi.confsched2019.model.StaffContents
 import io.github.droidkaigi.confsched2019.model.StaffSearchResult
 import io.github.droidkaigi.confsched2019.system.actioncreator.ErrorHandler
+import io.github.droidkaigi.confsched2019.util.ScreenLifecycle
+import io.github.droidkaigi.confsched2019.util.coroutineScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -18,8 +20,8 @@ import javax.inject.Inject
 class StaffSearchActionCreator @Inject constructor(
     override val dispatcher: Dispatcher,
     private val staffRepository: StaffRepository,
-    @PageScope private val lifecycle: Lifecycle
-) : CoroutineScope by lifecycle.coroutineScope, ErrorHandler {
+    private val screenLifecycle: ScreenLifecycle
+) : CoroutineScope by screenLifecycle.coroutineScope, ErrorHandler {
 
     fun load() = launch {
         try {

--- a/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/di/ScreenModule.kt
+++ b/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/di/ScreenModule.kt
@@ -1,0 +1,24 @@
+package io.github.droidkaigi.confsched2019.di
+
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.ViewModelProviders
+import dagger.Module
+import dagger.Provides
+import io.github.droidkaigi.confsched2019.ui.ScreenViewModel
+import io.github.droidkaigi.confsched2019.util.ScreenLifecycle
+
+@Module
+object ScreenModule {
+
+    @JvmStatic @Provides fun provideScreenViewModel(
+        activity: FragmentActivity
+    ): ScreenViewModel {
+        return ViewModelProviders.of(activity).get(ScreenViewModel::class.java)
+    }
+
+    @JvmStatic @Provides fun provideScreenLifecycle(
+        screenViewModel: ScreenViewModel
+    ): ScreenLifecycle {
+        return screenViewModel.lifecycle
+    }
+}

--- a/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/MainActivity.kt
+++ b/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/MainActivity.kt
@@ -32,6 +32,7 @@ import io.github.droidkaigi.confsched2019.announcement.ui.AnnouncementFragment
 import io.github.droidkaigi.confsched2019.announcement.ui.AnnouncementFragmentModule
 import io.github.droidkaigi.confsched2019.databinding.ActivityMainBinding
 import io.github.droidkaigi.confsched2019.di.PageScope
+import io.github.droidkaigi.confsched2019.di.ScreenModule
 import io.github.droidkaigi.confsched2019.ext.android.changed
 import io.github.droidkaigi.confsched2019.floormap.ui.FloorMapFragment
 import io.github.droidkaigi.confsched2019.floormap.ui.FloorMapFragmentModule
@@ -247,7 +248,7 @@ abstract class MainActivityModule {
 
     @Module
     abstract class MainActivityBuilder {
-        @ContributesAndroidInjector(modules = [MainActivityModule::class])
+        @ContributesAndroidInjector(modules = [MainActivityModule::class, ScreenModule::class])
         abstract fun contributeMainActivity(): MainActivity
     }
 }

--- a/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/ScreenViewModel.kt
+++ b/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/ScreenViewModel.kt
@@ -1,0 +1,17 @@
+package io.github.droidkaigi.confsched2019.ui
+
+import androidx.lifecycle.ViewModel
+import io.github.droidkaigi.confsched2019.util.ScreenLifecycle
+
+class ScreenViewModel : ViewModel() {
+
+    val lifecycle: ScreenLifecycle = ScreenLifecycle()
+
+    init {
+        lifecycle.dispatchOnInit()
+    }
+
+    override fun onCleared() {
+        lifecycle.dispatchOnCleared()
+    }
+}

--- a/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/util/ScreenLifecycle.kt
+++ b/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/util/ScreenLifecycle.kt
@@ -1,0 +1,50 @@
+package io.github.droidkaigi.confsched2019.util
+
+import androidx.annotation.IntDef
+
+class ScreenLifecycle {
+
+    companion object {
+        const val NONE = 0
+        const val INIT = 1
+        const val CLEARED = 2
+
+        @Target(AnnotationTarget.TYPE, AnnotationTarget.PROPERTY)
+        @IntDef(
+            NONE,
+            INIT,
+            CLEARED
+        )
+        annotation class State
+    }
+
+    @State
+    internal var state: Int = NONE
+
+    private val onInitHooks = HashSet<(() -> Unit)>()
+    private val onDestroyHooks = HashSet<(() -> Unit)>()
+
+    fun onInit(r: (() -> Unit)) {
+        onInitHooks.add(r)
+        if (state == INIT) {
+            r()
+        }
+    }
+
+    fun onCleared(r: (() -> Unit)) {
+        onDestroyHooks.add(r)
+        if (state == CLEARED) {
+            r()
+        }
+    }
+
+    fun dispatchOnInit() {
+        state = INIT
+        onInitHooks.forEach { it() }
+    }
+
+    fun dispatchOnCleared() {
+        state = CLEARED
+        onDestroyHooks.forEach { it() }
+    }
+}

--- a/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/util/ScreenLifecycleExt.kt
+++ b/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/util/ScreenLifecycleExt.kt
@@ -1,0 +1,28 @@
+package io.github.droidkaigi.confsched2019.util
+
+import io.github.droidkaigi.confsched2019.ext.android.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * This implementation refers to https://github.com/Kotlin/kotlinx.coroutines/pull/760
+ */
+fun ScreenLifecycle.createJob(
+    state: @ScreenLifecycle.Companion.State Int = ScreenLifecycle.NONE
+): Job {
+    require(state != ScreenLifecycle.CLEARED) {
+        "CLEARED is a terminal state that is forbidden for createJob(…), to avoid leaks."
+    }
+    return SupervisorJob().also { job ->
+        when (state) {
+            ScreenLifecycle.CLEARED -> job.cancel()
+            else -> GlobalScope.launch(Dispatchers.Main) {
+                onCleared {
+                    job.cancel()
+                }
+            }
+        }
+    }
+}

--- a/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/util/cachedLifecycleCoroutineScopes.kt
+++ b/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/util/cachedLifecycleCoroutineScopes.kt
@@ -1,0 +1,27 @@
+package io.github.droidkaigi.confsched2019.util
+
+import io.github.droidkaigi.confsched2019.ext.android.Dispatchers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import java.util.concurrent.ConcurrentHashMap
+
+private val cachedLifecycleCoroutineScopes = ConcurrentHashMap<ScreenLifecycle, CoroutineScope>()
+private val cachedLifecycleJobs = ConcurrentHashMap<ScreenLifecycle, Job>()
+
+val ScreenLifecycle.coroutineScope: CoroutineScope
+    get() = cachedLifecycleCoroutineScopes[this] ?: job.let { job ->
+        val newScope = CoroutineScope(job + Dispatchers.Main)
+        if (job.isActive) {
+            cachedLifecycleCoroutineScopes[this] = newScope
+            job.invokeOnCompletion { cachedLifecycleCoroutineScopes -= this }
+        }
+        newScope
+    }
+
+val ScreenLifecycle.job: Job
+    get() = cachedLifecycleJobs[this] ?: createJob().also {
+        if (it.isActive) {
+            cachedLifecycleJobs[this] = it
+            it.invokeOnCompletion { cachedLifecycleJobs -= this }
+        }
+    }


### PR DESCRIPTION
## Issue
- 画面回転でjobがcancelされていたため 
  - Twitter: https://twitter.com/magie_pooh/status/1085838122577874944 

## Overview (Required)
- ActivityのViewModelと同じライフサイクルを保持するScreenViewModelを作成
- ScreenViewModelのライフサイクルを提供するScreenLifecycleを作成
- ScreenLifecycleからJobを管理
- ActionCreatorで使っていたPageScopeのLifecycleをScreenLifecycleへ置き換え

## Links
- ScreenScope: ref. https://speakerdeck.com/ogaclejapan/how-to-keep-data-between-orientation-changes

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />