### PR TITLE
fix ios default local

### DIFF
--- a/model/src/iosMain/kotlin/io/github/droidkaigi/confsched2019/model/Lang.kt
+++ b/model/src/iosMain/kotlin/io/github/droidkaigi/confsched2019/model/Lang.kt
@@ -3,4 +3,4 @@ package io.github.droidkaigi.confsched2019.model
 import platform.Foundation.NSLocale
 import platform.Foundation.preferredLanguages
 
-actual fun defaultLang() = if (NSLocale.preferredLanguages.first() == "ja") Lang.JA else Lang.EN
+actual fun defaultLang() = if (NSLocale.preferredLanguages.first().toString().startsWith("ja")) Lang.JA else Lang.EN


### PR DESCRIPTION
`NSLocal.preferredLanguages` returns Language IDs
https://developer.apple.com/documentation/foundation/nslocale/1415614-preferredlanguages
https://qiita.com/m1takahashi/items/e28858198ed8848a2738
