### PR TITLE
Fix blink SessionDetail is blinking when favorite button clicked

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
@@ -170,7 +170,7 @@ class SessionDetailFragment : DaggerFragment() {
         binding.speechSession = session
         val lang = defaultLang()
         binding.lang = lang
-        setupSessionDescription()
+        setupSessionDescription(session.desc)
         binding.timeZoneOffset = DateTimeSpan(hours = 9) // FIXME Get from device setting
 
         binding.sessionTitle.text = session.title.getByLang(lang)
@@ -187,8 +187,6 @@ class SessionDetailFragment : DaggerFragment() {
         session.message?.let { message ->
             binding.sessionMessage.text = message.getByLang(defaultLang())
         }
-
-        binding.sessionDescription.text = session.desc
 
         val speakerItems = session
             .speakers
@@ -234,20 +232,22 @@ class SessionDetailFragment : DaggerFragment() {
         }
     }
 
-    private fun setupSessionDescription() {
+    private fun setupSessionDescription(fullText: String) {
         val textView = binding.sessionDescription
         textView.doOnPreDraw {
+            // check the number of lines if set full length text (this text is not displayed yet)
+            textView.text = fullText
+            // if lines are more than prescribed value then collapse
             if (textView.lineCount > 5 && showEllipsis) {
                 val end = textView.layout.getLineStart(5)
                 val ellipsis = getString(R.string.ellipsis_label)
                 val ellipsisColor = ContextCompat.getColor(requireContext(), R.color.colorSecondary)
                 val onClickListener = {
                     TransitionManager.beginDelayedTransition(binding.sessionLayout)
-                    val session = binding.speechSession?.desc
-                    binding.sessionDescription.text = session
+                    textView.text = fullText
                     showEllipsis = !showEllipsis
                 }
-                val detailText = textView.text.subSequence(0, end - ellipsis.length)
+                val detailText = fullText.subSequence(0, end - ellipsis.length)
                 val text = buildSpannedString {
                     clickableSpan(onClickListener, {
                         append(detailText)
@@ -256,8 +256,8 @@ class SessionDetailFragment : DaggerFragment() {
                         }
                     })
                 }
-                binding.sessionDescription.setText(text, TextView.BufferType.SPANNABLE)
-                binding.sessionDescription.movementMethod = LinkMovementMethod.getInstance()
+                textView.setText(text, TextView.BufferType.SPANNABLE)
+                textView.movementMethod = LinkMovementMethod.getInstance()
             }
         }
     }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
@@ -1,5 +1,7 @@
 package io.github.droidkaigi.confsched2019.session.ui
 
+import android.graphics.Paint
+import android.graphics.Rect
 import android.os.Bundle
 import android.text.SpannableStringBuilder
 import android.text.TextPaint
@@ -60,6 +62,7 @@ class SessionDetailFragment : DaggerFragment() {
 
     private lateinit var sessionDetailFragmentArgs: SessionDetailFragmentArgs
     private var showEllipsis = true
+    private val ellipsisLineCount = 5
 
     private val groupAdapter
         get() = binding.sessionSpeakers.adapter as GroupAdapter<*>
@@ -170,7 +173,7 @@ class SessionDetailFragment : DaggerFragment() {
         binding.speechSession = session
         val lang = defaultLang()
         binding.lang = lang
-        setupSessionDescription()
+        setupSessionDescription(session.desc)
         binding.timeZoneOffset = DateTimeSpan(hours = 9) // FIXME Get from device setting
 
         binding.sessionTitle.text = session.title.getByLang(lang)
@@ -187,8 +190,6 @@ class SessionDetailFragment : DaggerFragment() {
         session.message?.let { message ->
             binding.sessionMessage.text = message.getByLang(defaultLang())
         }
-
-        binding.sessionDescription.text = session.desc
 
         val speakerItems = session
             .speakers
@@ -234,20 +235,20 @@ class SessionDetailFragment : DaggerFragment() {
         }
     }
 
-    private fun setupSessionDescription() {
-        val textView = binding.sessionDescription
-        textView.doOnPreDraw {
-            if (textView.lineCount > 5 && showEllipsis) {
-                val end = textView.layout.getLineStart(5)
+    private fun setupSessionDescription(description: String) {
+        binding.sessionDescription.doOnPreDraw {
+            val expectedLineCount = computeLineCount(description)
+            if (expectedLineCount > ellipsisLineCount && showEllipsis) {
+                val lineLength = description.length / expectedLineCount
+                val end = lineLength * ellipsisLineCount
                 val ellipsis = getString(R.string.ellipsis_label)
                 val ellipsisColor = ContextCompat.getColor(requireContext(), R.color.colorSecondary)
                 val onClickListener = {
                     TransitionManager.beginDelayedTransition(binding.sessionLayout)
-                    val session = binding.speechSession?.desc
-                    binding.sessionDescription.text = session
+                    binding.sessionDescription.text = description
                     showEllipsis = !showEllipsis
                 }
-                val detailText = textView.text.subSequence(0, end - ellipsis.length)
+                val detailText = description.subSequence(0, end - ellipsis.length)
                 val text = buildSpannedString {
                     clickableSpan(onClickListener, {
                         append(detailText)
@@ -258,6 +259,8 @@ class SessionDetailFragment : DaggerFragment() {
                 }
                 binding.sessionDescription.setText(text, TextView.BufferType.SPANNABLE)
                 binding.sessionDescription.movementMethod = LinkMovementMethod.getInstance()
+            } else {
+                binding.sessionDescription.text = description
             }
         }
     }
@@ -275,6 +278,15 @@ class SessionDetailFragment : DaggerFragment() {
                 // nothing
             }
         }, builderAction)
+    }
+
+    private fun computeLineCount(fullText: String): Int {
+        if (binding.sessionDescription.width == 0) return 0
+        val rect = Rect()
+        val paint = Paint()
+        paint.textSize = binding.sessionDescription.textSize
+        paint.getTextBounds(fullText, 0, fullText.length, rect)
+        return rect.width() / binding.sessionDescription.width
     }
 
     private fun applyServiceSessionLayout(session: ServiceSession) {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeakerItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeakerItem.kt
@@ -71,7 +71,7 @@ class SpeakerItem @AssistedInject constructor(
         other as SpeakerItem
 
         if (speaker != other.speaker) return false
-        if (query == null || other.query == null || query != other.query) return false
+        if (query != other.query) return false
 
         return true
     }


### PR DESCRIPTION
## Issue
- close #549 

## Overview (Required)
- Blinking was triggered that checking lineCount after setText (see figure1).
- This PR changes checking lineCount before setText
- and fix SpeakerItem equals method

![figure1](https://user-images.githubusercontent.com/7608725/51593856-78fc3380-1f36-11e9-8448-0b782efdbe6d.gif)
figure1: slow motion

but at some points, there is a room of improve:

- ellipsis position is not exact same before situation (I think it is difficult to detect exact position before `setText`)
- It seems be better to split to CustomView such a draw logic

## Links
-

## Screenshot
Before | After
:--: | :--:
![before_ellipsis_position](https://user-images.githubusercontent.com/7608725/51594358-9bdb1780-1f37-11e9-939b-b0dac5cd6419.png) | ![after_ellipsis_position](https://user-images.githubusercontent.com/7608725/51594364-9f6e9e80-1f37-11e9-9037-2d98a1cdabc5.png)
![before](https://user-images.githubusercontent.com/7608725/51594373-a2698f00-1f37-11e9-9974-2742017276e6.gif) | ![after](https://user-images.githubusercontent.com/7608725/51594377-a5647f80-1f37-11e9-8b21-84a8d00a4465.gif)
