### PR TITLE
Display appropriate map when going from session detail to floormap

### DIFF
--- a/feature/floormap/src/main/java/io/github/droidkaigi/confsched2019/floormap/ui/FloorMapFragment.kt
+++ b/feature/floormap/src/main/java/io/github/droidkaigi/confsched2019/floormap/ui/FloorMapFragment.kt
@@ -20,6 +20,10 @@ class FloorMapFragment : DaggerFragment() {
 
     private lateinit var binding: FragmentFloorMapBinding
 
+    private val args: FloorMapFragmentArgs by lazy {
+        FloorMapFragmentArgs.fromBundle(arguments ?: Bundle())
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -67,6 +71,8 @@ class FloorMapFragment : DaggerFragment() {
                 return view == `object`
             }
         }
+
+        binding.floorMapTabLayout.getTabAt(args.tabIndex)?.select()
     }
 }
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
@@ -103,8 +103,12 @@ class SessionDetailFragment : DaggerFragment() {
                     )
                 }
                 R.id.session_place -> {
+                    val session = binding.session ?: return@setOnMenuItemClickListener false
+                    val tabIndex = if (session.room.name.contains("Hall")) 0 else 1
                     navController.navigate(
-                        SessionDetailFragmentDirections.actionSessionDetailToFloormap()
+                        SessionDetailFragmentDirections.actionSessionDetailToFloormap().apply {
+                            setTabIndex(tabIndex)
+                        }
                     )
                 }
             }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionDetailFragment.kt
@@ -104,7 +104,7 @@ class SessionDetailFragment : DaggerFragment() {
                 }
                 R.id.session_place -> {
                     val session = binding.session ?: return@setOnMenuItemClickListener false
-                    val tabIndex = if (session.room.name.contains("Hall")) 0 else 1
+                    val tabIndex = if (session.room.isFirstFloor()) 0 else 1
                     navController.navigate(
                         SessionDetailFragmentDirections.actionSessionDetailToFloormap().apply {
                             setTabIndex(tabIndex)

--- a/frontendcomponent/androidcomponent/src/main/res/navigation/navigation.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/navigation/navigation.xml
@@ -121,6 +121,11 @@
         android:name="io.github.droidkaigi.confsched2019.floormap.ui.FloorMapFragment"
         android:label="@string/map_label"
         >
+        <argument
+            android:name="tabIndex"
+            app:argType="integer"
+            android:defaultValue="0"
+        />
     </fragment>
     <fragment
         android:id="@+id/setting"

--- a/model/src/commonMain/kotlin/Room.kt
+++ b/model/src/commonMain/kotlin/Room.kt
@@ -4,4 +4,8 @@ package io.github.droidkaigi.confsched2019.model
 data class Room(
     val id: Int,
     val name: String
-) : AndroidParcel
+) : AndroidParcel {
+    fun isFirstFloor(): Boolean {
+        return name.contains("Hall")
+    }
+}


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2019/issues/581

## Overview (Required)
- If the session room name does not contains "Hall", 5F floor map is displayed.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/744059/51609037-744a7600-1f5c-11e9-89d0-e488a5b2aa32.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/744059/51609129-a52aab00-1f5c-11e9-9374-20dd2c1d970e.gif" width="300" />
