### PR TITLE
Fixed sponsor page could not be opened due to json strict mode

### DIFF
--- a/data/api-impl/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/KtorDroidKaigiApi.kt
+++ b/data/api-impl/src/commonMain/kotlin/io/github/droidkaigi/confsched2019/data/api/KtorDroidKaigiApi.kt
@@ -60,10 +60,12 @@ open class KtorDroidKaigiApi constructor(
     }
 
     override suspend fun getSponsors(): SponsorResponse {
-        return httpClient.get<SponsorResponseImpl> {
+        val rawResponse = httpClient.get<String> {
             url("$apiEndpoint/sponsors")
             accept(ContentType.Application.Json)
         }
+
+        return JSON.nonstrict.parse(SponsorResponseImpl.serializer(), rawResponse)
     }
 
     override suspend fun getStaffs(): StaffResponse {


### PR DESCRIPTION
## Issue
- None

## Overview (Required)

- The server response contains `kind` field so json mode should be non-strict.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/4340693/51665480-2e92b980-1fff-11e9-88e7-8ea4d4d02d73.png" width="300" /> | <img src="https://user-images.githubusercontent.com/4340693/51665545-597d0d80-1fff-11e9-9ad8-b166ead3b44a.png" width="300" />
