### PR TITLE
Fix ellipsis position was shifted in some situation

### DIFF
--- a/frontendcomponent/androidcomponent/src/main/res/values-ja/strings.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values-ja/strings.xml
@@ -6,7 +6,7 @@
     <string name="about_label">DroidKaigi とは</string>
     <string name="sponsor_label">スポンサーページ</string>
     <string name="survey_label">全体アンケート</string>
-    <string name="ellipsis_label">…続きを読む</string>
+    <string name="ellipsis_label">続きを読む</string>
     <string name="session_survey_label">セッションフィードバック</string>
     <string name="description_filter_applied">フィルター%1$sを適用</string>
     <string name="description_filter_not_applied">フィルター%1$sを解除</string>

--- a/frontendcomponent/androidcomponent/src/main/res/values/strings.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <string name="map_label">Floormap</string>
     <!-- Survey -->
     <string name="survey_label">Entire survey</string>
-    <string name="ellipsis_label">…続きを読む</string>
+    <string name="ellipsis_label">more</string>
     <string name="session_survey_label">Session survey</string>
     <!-- Search -->
     <string name="search_label" translatable="false">Search</string>


### PR DESCRIPTION
## Issue
- close #608 

## Overview (Required)
- in some situation, ellipsis position is shifted

## discussion point

If 5th line (that is prescribed value decided to ellipsize) contains line feed, it is shifted even if using `TextUtils.ellipsize`
so I decided to remove line feed(`\n`) from 5th line and after.

Pros:
- ellipsis positioned at the end of 5th line

Cons:
- in some cases, break 5th line (see 4th before/after screenshot)

how do you think?

## Screenshot
Before | After
:--: | :--:
![before_expected](https://user-images.githubusercontent.com/7608725/51685306-69154a00-2031-11e9-8a66-fc3a019a67b2.png) | ![after_expected](https://user-images.githubusercontent.com/7608725/51685312-6d416780-2031-11e9-8e65-f741cdb9c52b.png)
![before_english](https://user-images.githubusercontent.com/7608725/51685323-729eb200-2031-11e9-8ae1-13cddf8d90f8.png) | ![after_english](https://user-images.githubusercontent.com/7608725/51685338-7599a280-2031-11e9-87ff-6567c86766bc.png)
![before_line_break](https://user-images.githubusercontent.com/7608725/51685351-78949300-2031-11e9-9162-df96eceff0db.png) | ![after_line_break](https://user-images.githubusercontent.com/7608725/51685353-7c281a00-2031-11e9-81ea-550a3b0ab3a3.png)
![before_line_break_2](https://user-images.githubusercontent.com/7608725/51685361-80543780-2031-11e9-9471-ce5c38f46aa0.png) | ![after_line_break_2](https://user-images.githubusercontent.com/7608725/51685366-834f2800-2031-11e9-88f4-187433bbd7a7.png)
