### PR TITLE
Improve performance by caching UITableViewCell height for iOS

### DIFF
--- a/frontend/ios/DroidKaigi 2019/Scenes/Session/SessionTableViewCell.swift
+++ b/frontend/ios/DroidKaigi 2019/Scenes/Session/SessionTableViewCell.swift
@@ -66,6 +66,10 @@ class SessionTableViewCell: UITableViewCell, Reusable {
                 withHorizontalFittingPriority: horizontalFittingPriority,
                 verticalFittingPriority: verticalFittingPriority
         )
+        let hash = tagContents.hashValue ^ Int(targetSize.width).hashValue
+        if let cachedHeight = SessionCalculateHeightTableViewCell.cachedHeights[hash] {
+            return CGSize.init(width: targetSize.width, height: cachedHeight + defaultSize.height)
+        }
         struct Static {
             static let cell = SessionCalculateHeightTableViewCell(style: .default, reuseIdentifier: nil)
         }
@@ -79,6 +83,7 @@ class SessionTableViewCell: UITableViewCell, Reusable {
         cell.collectionView.layoutIfNeeded()
         cell.collectionView.collectionViewLayout.invalidateLayout()
         let collectionViewHeight = cell.collectionView.collectionViewLayout.collectionViewContentSize.height
+        SessionCalculateHeightTableViewCell.cachedHeights[hash] = collectionViewHeight
         return CGSize.init(width: targetSize.width, height: collectionViewHeight + defaultSize.height)
     }
 
@@ -186,6 +191,8 @@ extension SessionTableViewCell: UICollectionViewDataSource {
 
 
 final class SessionCalculateHeightTableViewCell: UITableViewCell {
+
+    static var cachedHeights = [Int: CGFloat]()
 
     var session: Session? {
         didSet {

--- a/frontend/ios/DroidKaigi 2019/Scenes/Session/TagsCollectionViewCell.swift
+++ b/frontend/ios/DroidKaigi 2019/Scenes/Session/TagsCollectionViewCell.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 import ios_combined
 
-enum TagContent {
+enum TagContent: Hashable {
     case category(category: ios_combined.Category)
     case lang(lang: Lang)
     case beginner


### PR DESCRIPTION
## Overview (Required)
- cache calculated tableView cell height


To reduce CPU usage, cache `SessioncCalculateHeightTableViewCell` height.

cf.  We create another 'virtual' cell (`SessioncCalculateHeightTableViewCell`)  to calculate `SessionTableViewCell` height every time cell is appearing.

## How to measure

1. Scroll  top to bottom, bottom to top by same speed as possible some times.
2. check `CPU Report (Xcode)`

## Result

reduce CPU usage about `5 ~ 10%`.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/12663296/51694575-7f78d100-2044-11e9-8105-1944b6ac3e62.png" width="300" /> | <img src="https://user-images.githubusercontent.com/12663296/51694631-97505500-2044-11e9-9788-79358eb3b1f3.png" width="300" />

