### PR TITLE
Fix max width of tags for iOS

### DIFF
--- a/frontend/ios/DroidKaigi 2019/Scenes/Session/TagsCollectionViewCell.swift
+++ b/frontend/ios/DroidKaigi 2019/Scenes/Session/TagsCollectionViewCell.swift
@@ -83,7 +83,7 @@ class TagsCollectionViewCell: UICollectionViewCell, Reusable {
         label.padding = UIEdgeInsets(top: 6, left: 10, bottom: 6, right: 10)
         label.font = UIFont.systemFont(ofSize: 12)
         label.numberOfLines = 1
-        label.textAlignment = .center
+        label.textAlignment = .left
         label.lineBreakMode = .byTruncatingTail
         label.clipsToBounds = true
         return label
@@ -93,7 +93,6 @@ class TagsCollectionViewCell: UICollectionViewCell, Reusable {
         addSubview(label)
         label.snp.makeConstraints {
             $0.edges.equalToSuperview()
-            $0.width.lessThanOrEqualTo(230)
         }
     }
 }

--- a/frontend/ios/DroidKaigi 2019/Scenes/Session/TagsLeftAlignedCollectionViewFlowLayout.swift
+++ b/frontend/ios/DroidKaigi 2019/Scenes/Session/TagsLeftAlignedCollectionViewFlowLayout.swift
@@ -20,6 +20,13 @@ final class TagsLeftAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout 
             layoutAttribute.frame.origin.x = leftMargin
             leftMargin += layoutAttribute.frame.width + minimumInteritemSpacing
             maxY = max(layoutAttribute.frame.maxY, maxY)
+    
+            if let collectionView = collectionView {
+                let bounds = collectionView.bounds
+                let contentInset = collectionView.contentInset
+                let maxWidth = bounds.width - contentInset.left - contentInset.right
+                layoutAttribute.frame.size.width = min(maxWidth, layoutAttribute.bounds.width)
+            }
         }
         return attributes
     }


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- In small devices (SE, 5s, etc.), long tags is sticking out from a table view

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/5673994/51788813-add1ea00-21c5-11e9-98de-f88d4f49e19d.png" width="300" /> | <img src="https://user-images.githubusercontent.com/5673994/51788816-b88c7f00-21c5-11e9-9e76-3b4dd7a4bc8b.png" width="300" />