### PR TITLE
Remove some warnings(Not all)

### DIFF
--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -53,7 +53,8 @@ android {
     }
     packagingOptions {
         exclude 'META-INF/*.kotlin_module'
-        exclude 'META-INF/android.arch.navigation_navigation-*.version'
+        exclude 'META-INF/*.version'
+        exclude 'META-INF/proguard/*.pro'        
     }
 }
 

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -54,7 +54,7 @@ android {
     packagingOptions {
         exclude 'META-INF/*.kotlin_module'
         exclude 'META-INF/*.version'
-        exclude 'META-INF/proguard/*.pro'        
+        exclude 'META-INF/proguard/*.pro'
     }
 }
 

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -53,6 +53,7 @@ android {
     }
     packagingOptions {
         exclude 'META-INF/*.kotlin_module'
+        exclude 'META-INF/android.arch.navigation_navigation-*.version'
     }
 }
 

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -52,12 +52,7 @@ android {
         htmlOutput file("lint-results.html")
     }
     packagingOptions {
-        exclude 'META-INF/ktor-http.kotlin_module'
-        exclude 'META-INF/kotlinx-io.kotlin_module'
-        exclude 'META-INF/atomicfu.kotlin_module'
-        exclude 'META-INF/ktor-utils.kotlin_module'
-        exclude 'META-INF/kotlinx-coroutines-io.kotlin_module'
-        exclude 'META-INF/ktor-client-core.kotlin_module'
+        exclude 'META-INF/*.kotlin_module'
     }
 }
 


### PR DESCRIPTION
## Issue
- close #268 

## Overview (Required)
- Remove **some** warnings by excluding warned kotlin_modules.

```
packagingOptions {
        exclude 'META-INF/*.kotlin_module'
        exclude 'META-INF/*.version'
        exclude 'META-INF/proguard/*.pro'
}
```

We still have other warnings about `/META-INF/services/**` .
Because We need to research what services are required for this app.
Please read [here](https://github.com/DroidKaigi/conference-app-2019/issues/268#issuecomment-457836813) if you'd like to know more.
