### PR TITLE
Fix session detail title's invalid new line

### DIFF
--- a/feature/session/src/main/res/layout/fragment_session_detail.xml
+++ b/feature/session/src/main/res/layout/fragment_session_detail.xml
@@ -74,6 +74,7 @@
                 android:fitsSystemWindows="false"
                 android:minHeight="?attr/actionBarSize"
                 app:layoutDescription="@xml/motion_session_detail"
+                app:progress="0"
                 app:layout_scrollFlags="scroll|exitUntilCollapsed"
                 >
 


### PR DESCRIPTION
## Issue
- close #649 

## Overview (Required)
- Fix session detail title's new line with no scrolling.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/6965122/51799979-06f45900-226c-11e9-86b7-8158b4414465.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/6965122/51799987-14a9de80-226c-11e9-86b9-1f0f2886b1fd.gif" width="300" />
