### PR TITLE
Fix issue 651

### DIFF
--- a/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/MainActivity.kt
+++ b/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/MainActivity.kt
@@ -118,6 +118,13 @@ class MainActivity : DaggerAppCompatActivity() {
             // check drawer menu item/ apply when back key pressed
             checkCurrentDestinationIdInDrawer(destination.id)
 
+            // to avoid flickering, set current fragment background color to white
+            // see https://github.com/DroidKaigi/conference-app-2019/pull/521
+            supportFragmentManager.findFragmentById(R.id.root_nav_host_fragment)?.let { host ->
+                host.childFragmentManager
+                    .primaryNavigationFragment?.view?.setBackgroundColor(Color.WHITE)
+            }
+
             val config = PageConfiguration.getConfiguration(destination.id)
             binding.logo.isVisible = config.isShowLogoImage
             if (!config.hasTitle) supportActionBar?.title = ""
@@ -179,12 +186,6 @@ class MainActivity : DaggerAppCompatActivity() {
             // drawer close
             if (binding.drawerLayout.isDrawerOpen(binding.navView)) {
                 binding.drawerLayout.closeDrawer(binding.navView)
-            }
-            // to avoid flickering, set current fragment background color to white
-            // see https://github.com/DroidKaigi/conference-app-2019/pull/521
-            supportFragmentManager.findFragmentById(R.id.root_nav_host_fragment)?.let { host ->
-                host.childFragmentManager
-                    .primaryNavigationFragment?.view?.setBackgroundColor(Color.WHITE)
             }
             // navigate
             val handled = handleNavigation(item)


### PR DESCRIPTION
## Issue
- close #651 

## Overview (Required)
- the cause is showing both of navigation destination and source at the same time for a moment
- timeline has red background color, and others dose not have background color (transparent)
- when navigate to timeline via Navigation Component, red background color can be seen through
- avoid this behavior to set background color white programmatically (in PR #521 )
- but it be applied when navigate with drawer menu only, so I moved it into destinationChangedListener 

## Links
- https://github.com/DroidKaigi/conference-app-2019/pull/521

## Screenshot
Before | After
:--: | :--:
![before](https://user-images.githubusercontent.com/12663296/51799610-6bacb500-2266-11e9-822a-061ea46475d9.gif) | ![after](https://user-images.githubusercontent.com/7608725/51800620-1a57f200-2275-11e9-98bf-f14412d18cd1.gif)

