### PR TITLE
Fixed #656 bug

### DIFF
--- a/frontend/android/src/main/AndroidManifest.xml
+++ b/frontend/android/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             />
 
         <activity android:name=".ui.MainActivity"
-                  android:windowSoftInputMode="stateVisible|adjustPan">
+                  android:windowSoftInputMode="adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 


### PR DESCRIPTION
## Issue
- close #656

## Overview (Required)
- When stateVisible is present, the IME is displayed automatically
  - Delete unnecessary options

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
