### PR TITLE
Change OnPreDrawListener object to field variable to avoid leak

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionPageFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SessionPageFragment.kt
@@ -71,6 +71,16 @@ class SessionPageFragment : DaggerFragment() {
             }
     }
 
+    private val onPreDrawListener = object : ViewTreeObserver.OnPreDrawListener {
+        override fun onPreDraw(): Boolean {
+            binding.sessionsSheet.viewTreeObserver.removeOnPreDrawListener(this)
+            if (isDetached) return false
+            bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
+
+            return false
+        }
+    }
+
     private val args: SessionPageFragmentArgs by lazy {
         SessionPageFragmentArgs.fromBundle(arguments ?: Bundle())
     }
@@ -156,6 +166,11 @@ class SessionPageFragment : DaggerFragment() {
         }
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        teardownBottomSheetBehavior()
+    }
+
     private fun setupSessionsFragment() {
         val tab = SessionPage.pages[args.tabIndex]
         val fragment: Fragment = when (tab) {
@@ -180,17 +195,7 @@ class SessionPageFragment : DaggerFragment() {
 
     private fun setupBottomSheetBehavior() {
         bottomSheetBehavior.isHideable = false
-        binding.sessionsSheet.viewTreeObserver.addOnPreDrawListener(
-            object : ViewTreeObserver.OnPreDrawListener {
-                override fun onPreDraw(): Boolean {
-                    binding.sessionsSheet.viewTreeObserver.removeOnPreDrawListener(this)
-                    if (isDetached) return false
-                    bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
-
-                    return false
-                }
-            }
-        )
+        binding.sessionsSheet.viewTreeObserver.addOnPreDrawListener(onPreDrawListener)
         bottomSheetBehavior.addBottomSheetCallback(
             object : BottomSheetBehavior.BottomSheetCallback {
                 override fun onStateChanged(bottomSheet: View, newState: Int) {
@@ -200,6 +205,10 @@ class SessionPageFragment : DaggerFragment() {
                 }
             }
         )
+    }
+
+    private fun teardownBottomSheetBehavior() {
+        binding.sessionsSheet.viewTreeObserver.removeOnPreDrawListener(onPreDrawListener)
     }
 
     private fun <T> ChipGroup.setupFilter(


### PR DESCRIPTION
## Issue
- close #635 

## Overview (Required)
- The SessionPagesFragment is leaked, when it is destroyed before being drawn.
  - Change object function to function variable to add at onActivityCreated, remove at onDestroyView.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/17231507/51787547-cd154b00-21b6-11e9-86aa-0e1d00f7711f.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/17231507/51852793-2a053280-236a-11e9-9ff9-2a62834732f1.gif" width="300" />
