### PR TITLE
[iOS] Change API endpoint according to build configuration

### DIFF
--- a/data/api-impl/build.gradle
+++ b/data/api-impl/build.gradle
@@ -50,6 +50,13 @@ kotlin {
             }
         }
         iOSMain {
+            final String mode = project.findProperty("XCODE_CONFIGURATION")?.toUpperCase() ?: 'DEBUG'
+            if (mode == "RELEASE") {
+                kotlin.srcDirs += "src/iosMain/kotlinRelease"
+            } else {
+                kotlin.srcDirs += "src/iosMain/kotlinDebug"
+            }
+
             dependsOn commonMain
             dependencies {
                 implementation Dep.Ktor.clientIos

--- a/data/api-impl/build.gradle
+++ b/data/api-impl/build.gradle
@@ -50,13 +50,6 @@ kotlin {
             }
         }
         iOSMain {
-            final String mode = project.findProperty("XCODE_CONFIGURATION")?.toUpperCase() ?: 'DEBUG'
-            if (mode == "RELEASE") {
-                kotlin.srcDirs += "src/iosMain/kotlinRelease"
-            } else {
-                kotlin.srcDirs += "src/iosMain/kotlinDebug"
-            }
-
             dependsOn commonMain
             dependencies {
                 implementation Dep.Ktor.clientIos

--- a/data/api-impl/src/iosMain/kotlinDebug/io/github/droidkaigi/confsched2019/data/api/ApiEndpoint.kt
+++ b/data/api-impl/src/iosMain/kotlinDebug/io/github/droidkaigi/confsched2019/data/api/ApiEndpoint.kt
@@ -1,5 +1,3 @@
 package io.github.droidkaigi.confsched2019.data.api
 
-// TODO: Replace with code getting endpoint from iOS application build configurations.
-//       This is temporally implementation.
 internal actual fun apiEndpoint(): String = "https://droidkaigi2019-dev.appspot.com/api"

--- a/data/api-impl/src/iosMain/kotlinRelease/io/github/droidkaigi/confsched2019/data/api/ApiEndpoint.kt
+++ b/data/api-impl/src/iosMain/kotlinRelease/io/github/droidkaigi/confsched2019/data/api/ApiEndpoint.kt
@@ -1,0 +1,3 @@
+package io.github.droidkaigi.confsched2019.data.api
+
+internal actual fun apiEndpoint(): String = "https://droidkaigi-api.appspot.com/2019/api"

--- a/frontend/ioscombined/build.gradle
+++ b/frontend/ioscombined/build.gradle
@@ -53,8 +53,14 @@ kotlin {
             }
         }
         iOSMain {
+            final String mode = project.findProperty("XCODE_CONFIGURATION")?.toUpperCase() ?: 'DEBUG'
             projectsList.forEach {
                 kotlin.srcDirs += "${project(it).projectDir}/src/iosMain/kotlin"
+                if (mode == "RELEASE") {
+                    kotlin.srcDirs += "${project(it).projectDir}/src/iosMain/kotlinRelease"
+                } else {
+                    kotlin.srcDirs += "${project(it).projectDir}/src/iosMain/kotlinDebug"
+                }
             }
             dependencies {
                 projectsList.forEach {


### PR DESCRIPTION
## Issue
- close #674 

## Overview (Required)
- In addition to `src/iOSMain/kotlin`, one of
  `src/iOSMain/kotlinDebug`
   or
  `src/iOSMain/kotlinRelease`
  is also source directory now, according to Xcode configuration (Debug or Release)
- Move`ApiEndpoint.kt` to `kotlinDebug` and `kotlinRelease` , making it return appropriate endpoint

I couldn't find out the way to tell the configuration value to Kotlin source code. So I decided to switch  the whole source file itself.
`project.findProperty("XCODE_CONFIGURATION")` is used for detecting Xcode configuration. I don't know much about it 😇 but it is already used in `packForXCode` task in ioscombined/build.gradle.

Though I've also changed the api-impl/build.gradle, I think is not used for iOS build 🤔