### PR TITLE
アプリ起動前タップ&複数セッション同時タップ暫定対応

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
@@ -27,6 +27,7 @@ import io.github.droidkaigi.confsched2019.session.ui.actioncreator.SessionConten
 import io.github.droidkaigi.confsched2019.session.ui.bindingadapter.setHighlightText
 import io.github.droidkaigi.confsched2019.util.lazyWithParam
 import jp.wasabeef.picasso.transformations.CropCircleTransformation
+import java.lang.IllegalArgumentException
 import kotlin.math.max
 
 class SpeechSessionItem @AssistedInject constructor(
@@ -60,7 +61,12 @@ class SpeechSessionItem @AssistedInject constructor(
     override fun bind(viewBinding: ItemSessionBinding, position: Int) {
         with(viewBinding) {
             root.setOnClickListener {
-                navController.navigate(detailNavDirections)
+                try {
+                    navController.navigate(detailNavDirections)
+                } catch (e: IllegalArgumentException) {
+                    // FIXME: When launching the app and click session multiple times, cause Exception
+                    // see https://github.com/DroidKaigi/conference-app-2019/issues/664
+                }
             }
             session = speechSession
             lang = defaultLang()


### PR DESCRIPTION
## Issue
- ref: #664

## Overview (Required)
- アプリ起動時の描画完了前にタップするとクラッシュする問題の対応
- 複数のセッションを同時にタップするとクラッシュする問題の対応

## Screenshot
<img src="https://user-images.githubusercontent.com/45986582/52038160-b125f680-2574-11e9-8ee8-113e08cd3405.png" width="300" />
