### PR TITLE
Hotfix for No matching client found build error

### DIFF
--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -43,7 +43,6 @@ android {
     }
     buildTypes {
         debug {
-            applicationIdSuffix ".debug"
             debuggable true
         }
         staging {

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -43,6 +43,9 @@ android {
     }
     buildTypes {
         debug {
+            if (isCi || isReleaseBuild) {
+                applicationIdSuffix ".debug"
+            }
             debuggable true
         }
         staging {


### PR DESCRIPTION
## Overview (Required)
- Title says everything


```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':frontend:android:processDebugGoogleServices'.
> No matching client found for package name 'io.github.droidkaigi.confsched2019.debug.debug'
```