### PR TITLE
Upload release artifacts to GitHub release pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ bundletool.jar
 dpg
 toc.pb
 *.keystore
+.transart/
+transart

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-  - travis_release_build
+  - "travis/.*"
   - master
   - release
   - "/^v\\d+\\.\\d+(\\.\\d+)?(-\\S*)?$/"
@@ -19,6 +19,7 @@ matrix:
       - ".gradle"
     env:
     - RELEASE_BUILD=true
+    - PATH="$HOME/.bin:$PATH"
     android:
       components:
       - platform-tools
@@ -36,24 +37,24 @@ matrix:
       -in .travis/android/release.zip.enc -out release.zip -d
     - "./.travis/android/before_install.bash"
     script: ".travis/android/run.bash"
-  - language: objective-c
-    os: osx
-    osx_image: xcode10.1
-    xcode_workspace: frontend/ios/DroidKaigi\ 2019.xcworkspace
-    cache:
-    - directories:
-      - ios/frontend/vendor/bundle
-      - ios/frontend/Pods
-      - "$HOME/.gradle"
-      - "$HOME/.android"
-      - ".gradle"
-      - "$ANDROID_HOME"
-    env:
-    - ANDROID_HOME="$HOME/android-sdk"
-    before_install:
-    - pod repo update
-    - "./.travis/ios/before_install.bash"
-    script: ".travis/ios/run.bash"
+  # - language: objective-c
+  #   os: osx
+  #   osx_image: xcode10.1
+  #   xcode_workspace: frontend/ios/DroidKaigi\ 2019.xcworkspace
+  #   cache:
+  #   - directories:
+  #     - ios/frontend/vendor/bundle
+  #     - ios/frontend/Pods
+  #     - "$HOME/.gradle"
+  #     - "$HOME/.android"
+  #     - ".gradle"
+  #     - "$ANDROID_HOME"
+  #   env:
+  #   - ANDROID_HOME="$HOME/android-sdk"
+  #   before_install:
+  #   - pod repo update
+  #   - "./.travis/ios/before_install.bash"
+  #   script: ".travis/ios/run.bash"
 env:
   global:
   - secure: Jw5L3sTHnuivSj2+DPdqbgNhVvdr1Zg8bY1USNUNMl8sR1nIhupb8IFUfP/5ymJIUrXgOizVILJwRZX6AxD8RvxJfjzm+A1ovh+ob+ymNQVUDKmWD8Ho2qPOpAEQiJIzPHzZnZIQHyZFOYC3hIhlNz48zSha3sT1ZD3PMJByGxsk3zU4ELlYZczR2pPkOR4h52mJES8WmcTI68Spl4ILBnQWM4AkrgyJBmBD0Ipt3DxvKDLC6vpH++NkXUzUUckyYp3K7g2RonvkoxdS7xzyYJdfhgOHjgs6q1C+EzDveTwijtbdacQ9I0zqMCoPqNdj3Irt1htiVi9BwGcp43vPwfSM+mYNjZQg5qeNAaRL3qR72kMC8oiaOnoJmleYCFTz5VNOhsAi5KqyNXZcO5oziOwFOkAWiFIFR0mx+jcOakFsFrW2+LV+PePgjHZRvh27ZnDa9HGM237LUFYFdzv2haArJJL3C5EohZLmGXjzEE93P5seiZUvLnSAU40ut2pLG0e2nWDMudB3smLNF9x5N6C8EMlwhpoVDH1bvOX2ndZhJHBprh1vYIlDk7mKeQrVfmwu4JmkYhO+BLfMXiuK3Szac+g5riX9nsPXPM3WK0qcX5nZT+OH9awkAY4ykAT/tBR4pODPY99gL9l1RoKqJrlZAvYy8CyIcopNefqJNoI=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-  - "travis/.*"
+  - "/travis/.*/"
   - master
   - release
   - "/^v\\d+\\.\\d+(\\.\\d+)?(-\\S*)?$/"

--- a/.travis/android/before_install.bash
+++ b/.travis/android/before_install.bash
@@ -5,6 +5,14 @@ set -eu
 
 source "$(dirname $0)/../bash.source"
 
+mkdir "$HOME/.bin"
+
+curl -sL "https://raw.githubusercontent.com/jmatsu/dpg/master/install.bash" | bash
+curl -sL "https://raw.githubusercontent.com/jmatsu/transart/master/install.bash" | bash
+
+cp ./dpg "$HOME/.bin/"
+cp ./transart "$HOME/.bin/"
+
 unzip release.zip
 
 ./gradlew androidDependenciesExtra getDependencies | grep "Dependencies for" --line-buffered

--- a/.travis/android/release_template.travis.erb
+++ b/.travis/android/release_template.travis.erb
@@ -1,0 +1,6 @@
+<%= ENV.fetch('RELEASE_TAG_NAME') %>
+
+Built on
+
+- Travis trigged by <%= ENV.fetch('TRAVIS_EVENT_TYPE') %>
+- Build Id and No. <%= "#{ENV.fetch('TRAVIS_BUILD_ID')} and #{ENV.fetch('TRAVIS_BUILD_NUMBER')}" %>

--- a/.travis/android/run.bash
+++ b/.travis/android/run.bash
@@ -2,6 +2,11 @@
 
 set -eu
 
+die() {
+  echo "$*" 1>&2
+  exit 1
+}
+
 source "$(dirname $0)/../bash.source"
 
 source .release/bash.source
@@ -12,11 +17,30 @@ use_release_keystore
  ./gradlew bundleRelease --offline
 create_universal_apk_from_aab.bash $(find frontend/android/build/outputs -name "*.aab" | head -1)
 
-curl -sL "https://raw.githubusercontent.com/jmatsu/dpg/master/install.bash" | bash
-
-./dpg app upload --android \
+dpg app upload --android \
   --app-owner droidkaigi \
   --app "$UNIVERSAL_APK_PATH" \
   --token "$DEPLOYGATE_API_TOKEN" \
   --message "Release build of $(git rev-parse --short HEAD) at $(date)" \
-  --distribution-name "Production Build"
+  --distribution-name "Production Build" > .dpg_response
+
+export APP_VERSION_CODE=$(cat .dpg_response | jq -r ".results.version_code")
+export APP_VERSION_NAME=$(cat .dpg_response | jq -r ".results.version_name")
+
+if [[ -z "${TRAVIS_TAG:-}" ]] && [[ "${TRAVIS_BRANCH:-}" != "release" ]]; then
+  echo "do not upload to github releases"
+  exit 0
+fi
+
+if [[ -n "${TRAVIS_TAG:-}" ]]; then
+  if [[ "$TRAVIS_TAG" != "v$APP_VERSION_NAME" ]]; then
+    die "tag and version name are different! ($TRAVIS_TAG and $APP_VERSION_NAME)"
+  fi
+
+  export RELEASE_TAG_NAME="$TRAVIS_TAG"
+else
+  export RELEASE_TAG_NAME="release-draft"
+fi
+
+.travis/android/update_github_release.bash
+transart -f .travis/android/to_github.transart.yml transfer

--- a/.travis/android/to_github.transart.yml
+++ b/.travis/android/to_github.transart.yml
@@ -1,0 +1,14 @@
+version: 1
+save_dir: .transart
+source:
+  locations:
+  - file-name-pattern: (\.apk|\.aab|mapping\.txt)
+    path: .
+    type: local
+destination:
+  location:
+    api-token-name: GITHUB_ACCESS_TOKEN
+    reponame: conference-app-2019
+    strategy: draft
+    type: github-release
+    username: DroidKaigi

--- a/.travis/android/update_github_release.bash
+++ b/.travis/android/update_github_release.bash
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -eux
+
+create_release_draft() {
+    curl -X POST \
+        -H "Authorization: token $GITHUB_ACCESS_TOKEN" \
+        -d "$(jq -n \
+          --arg tag_name "$RELEASE_TAG_NAME" \
+          --arg target_commitish "$(git rev-parse HEAD)" \
+          --arg name "$RELEASE_TAG_NAME" \
+          --arg body "$(cat .travis/android/release_template)" \
+          '{ "draft": true, "name": $name, "tag_name": $tag_name, "target_commitish": $target_commitish, "body": $body }')" \
+        "https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases"
+}
+
+update_release_draft() {
+    local -r release_id="$1"
+
+    curl -X POST \
+        -H "Authorization: token $GITHUB_ACCESS_TOKEN" \
+        -d "$(jq -n \
+          --arg target_commitish "$(git rev-parse --short HEAD)" \
+          --arg body "$(cat .travis/android/release_template)" \
+          '{ "target_commitish": $target_commitish, "body": $body }')" \
+        "https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases/$release_id"
+}
+
+release_count() {
+    curl -X GET \
+        -H "Authorization: token $GITHUB_ACCESS_TOKEN" \
+        "https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases" | \
+        jq -r '.[] | select(.draft) | length'
+}
+
+get_release_id() {
+    curl -X GET \
+        -H "Authorization: token $GITHUB_ACCESS_TOKEN" \
+        "https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases" | \
+        jq -r --arg tag_name "$RELEASE_TAG_NAME" '.[] | select(.tag_name == $tag_name and .draft) | .id // -1'
+}
+
+ruby -rerb -e 'puts ERB.new(File.read(".travis/android/release_template.travis.erb")).result(binding)' > .travis/android/release_template
+
+release_id="$(get_release_id)"
+
+if let "${release_id:--1} > 0"; then
+    update_release_draft "$release_id"
+else
+    create_release_draft
+fi

--- a/.travis/android/update_github_release.bash
+++ b/.travis/android/update_github_release.bash
@@ -26,11 +26,12 @@ update_release_draft() {
         "https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases/$release_id"
 }
 
-release_count() {
+draft_count() {
     curl -X GET \
         -H "Authorization: token $GITHUB_ACCESS_TOKEN" \
         "https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases" | \
-        jq -r '.[] | select(.draft) | length'
+        jq -r '.[] | select(.draft) // [] | length' 
+        # this query does not return the size of draft releases actually but it's okay for now.
 }
 
 get_release_id() {
@@ -46,6 +47,8 @@ release_id="$(get_release_id)"
 
 if let "${release_id:--1} > 0"; then
     update_release_draft "$release_id"
-else
+elif let "$(draft_count) == 0"; then
     create_release_draft
+else
+    die 'a draft exists. could not determine where I should upload to'
 fi

--- a/.travis/android/update_github_release.bash
+++ b/.travis/android/update_github_release.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux
+set -eu
 
 create_release_draft() {
     curl -X POST \


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- the 2nd part of the automated release flow... as a fallback, we need to get artifacts from anywhere with some metadata.
- Travis will upload apk, aab, mapping.txt to a GitHub release.

## Links
-
