### PR TITLE
[iOS] Fix safe area cropping issue (Part2).

### DIFF
--- a/frontend/ios/DroidKaigi 2019/Scenes/FloorMap/FloorMap.storyboard
+++ b/frontend/ios/DroidKaigi 2019/Scenes/FloorMap/FloorMap.storyboard
@@ -40,11 +40,11 @@
                         <constraints>
                             <constraint firstItem="f6t-AS-WzK" firstAttribute="top" secondItem="3E5-ua-Q8C" secondAttribute="top" id="7JA-9c-2as"/>
                             <constraint firstItem="yn6-Tb-Xe4" firstAttribute="top" secondItem="f6t-AS-WzK" secondAttribute="bottom" id="9qp-pw-tRb"/>
-                            <constraint firstItem="yn6-Tb-Xe4" firstAttribute="leading" secondItem="3E5-ua-Q8C" secondAttribute="leading" id="EbR-7K-XgK"/>
-                            <constraint firstItem="3E5-ua-Q8C" firstAttribute="bottom" secondItem="yn6-Tb-Xe4" secondAttribute="bottom" id="Uab-aF-Sa0"/>
-                            <constraint firstItem="3E5-ua-Q8C" firstAttribute="trailing" secondItem="f6t-AS-WzK" secondAttribute="trailing" id="dgY-6Q-Peh"/>
-                            <constraint firstItem="f6t-AS-WzK" firstAttribute="leading" secondItem="3E5-ua-Q8C" secondAttribute="leading" id="hze-uN-uwX"/>
-                            <constraint firstItem="3E5-ua-Q8C" firstAttribute="trailing" secondItem="yn6-Tb-Xe4" secondAttribute="trailing" id="tgs-Ou-Z4o"/>
+                            <constraint firstItem="yn6-Tb-Xe4" firstAttribute="leading" secondItem="EM1-8B-aWL" secondAttribute="leading" id="EbR-7K-XgK"/>
+                            <constraint firstAttribute="bottom" secondItem="yn6-Tb-Xe4" secondAttribute="bottom" id="Uab-aF-Sa0"/>
+                            <constraint firstAttribute="trailing" secondItem="f6t-AS-WzK" secondAttribute="trailing" id="dgY-6Q-Peh"/>
+                            <constraint firstItem="f6t-AS-WzK" firstAttribute="leading" secondItem="EM1-8B-aWL" secondAttribute="leading" id="hze-uN-uwX"/>
+                            <constraint firstAttribute="trailing" secondItem="yn6-Tb-Xe4" secondAttribute="trailing" id="tgs-Ou-Z4o"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="3E5-ua-Q8C"/>
                     </view>
@@ -66,7 +66,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" maximumZoomScale="8" translatesAutoresizingMaskIntoConstraints="NO" id="NH5-29-ujb">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" alwaysBounceHorizontal="YES" maximumZoomScale="8" translatesAutoresizingMaskIntoConstraints="NO" id="NH5-29-ujb">
                                 <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="LPH-ux-lga">
@@ -92,9 +92,9 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="Jsu-dw-ciA" firstAttribute="trailing" secondItem="NH5-29-ujb" secondAttribute="trailing" id="1gg-Yu-7RZ"/>
-                            <constraint firstItem="NH5-29-ujb" firstAttribute="leading" secondItem="Jsu-dw-ciA" secondAttribute="leading" id="SyH-cJ-zuh"/>
-                            <constraint firstItem="Jsu-dw-ciA" firstAttribute="bottom" secondItem="NH5-29-ujb" secondAttribute="bottom" id="rwU-D3-1Pf"/>
+                            <constraint firstAttribute="trailing" secondItem="NH5-29-ujb" secondAttribute="trailing" id="1gg-Yu-7RZ"/>
+                            <constraint firstItem="NH5-29-ujb" firstAttribute="leading" secondItem="17p-zy-eMh" secondAttribute="leading" id="SyH-cJ-zuh"/>
+                            <constraint firstAttribute="bottom" secondItem="NH5-29-ujb" secondAttribute="bottom" id="rwU-D3-1Pf"/>
                             <constraint firstItem="NH5-29-ujb" firstAttribute="top" secondItem="Jsu-dw-ciA" secondAttribute="top" id="zhk-d4-Ljh"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Jsu-dw-ciA"/>

--- a/frontend/ios/DroidKaigi 2019/Scenes/MainViewController.storyboard
+++ b/frontend/ios/DroidKaigi 2019/Scenes/MainViewController.storyboard
@@ -33,17 +33,17 @@
                                 <cells/>
                             </collectionView>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n9n-OP-LN7">
-                                <rect key="frame" x="0.0" y="60" width="375" height="558"/>
+                                <rect key="frame" x="0.0" y="60" width="375" height="607"/>
                             </scrollView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="n9n-OP-LN7" firstAttribute="trailing" secondItem="lch-pa-bTQ" secondAttribute="trailing" id="DW8-3K-wrG"/>
+                            <constraint firstItem="n9n-OP-LN7" firstAttribute="trailing" secondItem="7qW-CI-QDB" secondAttribute="trailing" id="DW8-3K-wrG"/>
                             <constraint firstItem="n9n-OP-LN7" firstAttribute="bottom" secondItem="7qW-CI-QDB" secondAttribute="bottom" id="Y03-MH-Jck"/>
                             <constraint firstItem="n9n-OP-LN7" firstAttribute="top" secondItem="UlX-SQ-8e8" secondAttribute="bottom" id="dws-dJ-W8O"/>
-                            <constraint firstItem="UlX-SQ-8e8" firstAttribute="leading" secondItem="lch-pa-bTQ" secondAttribute="leading" id="e0n-Wi-4pV"/>
-                            <constraint firstItem="UlX-SQ-8e8" firstAttribute="trailing" secondItem="lch-pa-bTQ" secondAttribute="trailing" id="mNG-rj-m2R"/>
-                            <constraint firstItem="n9n-OP-LN7" firstAttribute="leading" secondItem="lch-pa-bTQ" secondAttribute="leading" id="vYb-PL-xlU"/>
+                            <constraint firstItem="UlX-SQ-8e8" firstAttribute="leading" secondItem="7qW-CI-QDB" secondAttribute="leading" id="e0n-Wi-4pV"/>
+                            <constraint firstItem="UlX-SQ-8e8" firstAttribute="trailing" secondItem="7qW-CI-QDB" secondAttribute="trailing" id="mNG-rj-m2R"/>
+                            <constraint firstItem="n9n-OP-LN7" firstAttribute="leading" secondItem="7qW-CI-QDB" secondAttribute="leading" id="vYb-PL-xlU"/>
                             <constraint firstItem="UlX-SQ-8e8" firstAttribute="top" secondItem="lch-pa-bTQ" secondAttribute="top" id="yQ8-Z1-kqF"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="lch-pa-bTQ"/>


### PR DESCRIPTION
## Issue
- no numbering.

## Overview (Required)
Fix a SafeArea cropping issue. 
See attached screenshots.

This PR changes following settings.

**MainViewController.storyboard**
- Fit Button Bar View s trailing/leading edsge to superview.
- Fit Container View's trailing/leading edsge to superview.

**FloorMap.storyboard**
- Fit Button Bar View s trailing/leading edsge to superview.
- Fit Container View's trailing/leading/bottom edsge to superview.
- Fit Scroll View's trailing/leading/bottom edsge to superview.
- Enable Scroll View's Horizontally/Vertically Bounce.

**note**
- Screenshotでは提示できていませんが、スワイプによるページ移動にて次ページの表示内容がSafeArea端から出現するような状況だったため、Container Viewの制約を修正しました。
- FloorMapにてScroll Viewの範囲を画面一杯に広げる修正をしましたが、これの弊害として、デフォルトスケール時にマップの下部がホームインジケータに被る状況となっています。Bounceを有効にすることでユーザが必要に応じてホームインジケータから避けれるようにしました。

## Links
-

## Screenshot
Before (session list) | Before (floor map) 
:--: | :--: 
<img width="300" alt="before_session1" src="https://user-images.githubusercontent.com/29206446/52159289-6bd50680-26e5-11e9-8b34-f44da9e983a1.png"> | <img width="300" alt="before_floormap1" src="https://user-images.githubusercontent.com/29206446/52159292-78f1f580-26e5-11e9-95df-8e7fba44b00f.png"> 

After (session list) | After  (floor map)
:--: | :--:
<img width="300" alt="after_session1" src="https://user-images.githubusercontent.com/29206446/52159297-8ad39880-26e5-11e9-807f-5e3dd9da5597.png"> | <img width="300" alt="after_floormap1" src="https://user-images.githubusercontent.com/29206446/52159296-8ad39880-26e5-11e9-9358-82e2e384f81a.png">
