### PR TITLE
Update AGP Version to 3.4.0-beta03

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We would be happy if you ran the command below before sending pull requests to i
 
 ## Requirements
 
-- Android Studio 3.4 Beta 2 and higher. You can download it from [this page](https://developer.android.com/studio/archive?hl=en).
+- Android Studio 3.4 Beta 3 and higher. You can download it from [this page](https://developer.android.com/studio/archive?hl=en).
 - Android Studio Kotlin Plugin v1.3.20-release-Studio<AS version>
 
 **Check out following status.**  

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -3,7 +3,7 @@ package dependencies
 @Suppress("unused")
 object Dep {
     object GradlePlugin {
-        val android = "com.android.tools.build:gradle:3.4.0-beta02"
+        val android = "com.android.tools.build:gradle:3.4.0-beta03"
         val r8 = "com.android.tools:r8:1.3.52"
         val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Kotlin.version}"
         val kotlinSerialization = "org.jetbrains.kotlin:kotlin-serialization:${Kotlin.version}"


### PR DESCRIPTION
## Overview (Required)
- AGP 3.4.0 beta 2 and AS 3.4.0 Beta 3 are not compatible.
