### PR TITLE
Feature/announcement deeplink

### DIFF
--- a/frontend/android/src/main/AndroidManifest.xml
+++ b/frontend/android/src/main/AndroidManifest.xml
@@ -56,6 +56,30 @@
                     android:scheme="https"
                     />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+
+                <data
+                    android:host="droidkaigi.jp"
+                    android:path="/2019/announcement"
+                    android:scheme="https"
+                    />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+
+                <data
+                    android:host="droidkaigi.jp"
+                    android:path="/2019/en/announcement"
+                    android:scheme="https"
+                    />
+            </intent-filter>
         </activity>
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"

--- a/frontend/android/src/main/AndroidManifest.xml
+++ b/frontend/android/src/main/AndroidManifest.xml
@@ -26,7 +26,8 @@
             />
 
         <activity android:name=".ui.MainActivity"
-                  android:windowSoftInputMode="adjustPan">
+                  android:windowSoftInputMode="adjustPan"
+                  android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/frontendcomponent/androidcomponent/src/main/res/navigation/navigation.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/navigation/navigation.xml
@@ -126,6 +126,8 @@
         android:name="io.github.droidkaigi.confsched2019.announcement.ui.AnnouncementFragment"
         android:label="@string/announce_label"
         >
+        <deepLink app:uri="droidkaigi.jp/2019/announcement"/>
+        <deepLink app:uri="droidkaigi.jp/2019/en/announcement"/>
     </fragment>
     <fragment
         android:id="@+id/sponsor"


### PR DESCRIPTION
## Issue
- close #714

## Overview (Required)
- added deep links to the announcement page
- specified activity launchMode to singleTask
   otherwise, the app could be launched on other apps when the deep link is tapped which is on other apps like Facebook, LINE...etc.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
