### PR TITLE
Add session survey store test

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -168,8 +168,8 @@ object Dep {
     }
 
     object MockK {
-        val jvm = "io.mockk:mockk:1.8.13.kotlin13"
-        val common = "io.mockk:mockk-common:1.8.13.kotlin13"
+        val jvm = "io.mockk:mockk:1.9"
+        val common = "io.mockk:mockk-common:1.9"
     }
 
     object InjectedVmProvider {

--- a/feature/survey/src/test/java/io/github/droidkaigi/confsched2019/SessionFeedbackDummyDatas.kt
+++ b/feature/survey/src/test/java/io/github/droidkaigi/confsched2019/SessionFeedbackDummyDatas.kt
@@ -1,0 +1,16 @@
+package io.github.droidkaigi.confsched2019
+
+import io.github.droidkaigi.confsched2019.model.SessionFeedback
+
+fun dummySessionFeedbackData(): SessionFeedback {
+    return SessionFeedback(
+        "12345",
+        5,
+        4,
+        3,
+        2,
+        1,
+        "",
+        true
+    )
+}

--- a/feature/survey/src/test/java/io/github/droidkaigi/confsched2019/survey/ui/store/SessionSurveyStoreTest.kt
+++ b/feature/survey/src/test/java/io/github/droidkaigi/confsched2019/survey/ui/store/SessionSurveyStoreTest.kt
@@ -13,24 +13,19 @@ import io.mockk.MockKAnnotations
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
 class SessionSurveyStoreTest {
-    @JvmField
-    @Rule
-    val instantTaskExecutorRule = InstantTaskExecutorRule()
+    @JvmField @Rule val instantTaskExecutorRule = InstantTaskExecutorRule()
 
-    @Before
-    fun setUp() {
+    @Before fun setUp() {
         MockKAnnotations.init(this, relaxUnitFun = true)
         CoroutinePlugin.mainDispatcherHandler = { DirectDispatcher }
     }
 
-    @Test
-    fun loadingState() = runBlocking {
+    @Test fun loadingState() = runBlocking {
         val dispatcher = Dispatcher()
         val sessionSurveyStore = SessionSurveyStore(dispatcher)
         val observer = mockk<(LoadingState?) -> Unit>(relaxed = true)
@@ -45,8 +40,7 @@ class SessionSurveyStoreTest {
         verify { observer(LoadingState.LOADED) }
     }
 
-    @Test
-    fun sessionFeedback() = runBlocking {
+    @Test fun sessionFeedback() = runBlocking {
         val dispatcher = Dispatcher()
         val sessionSurveyStore = SessionSurveyStore(dispatcher)
         val observer = mockk<(SessionFeedback) -> Unit>(relaxed = true)
@@ -55,7 +49,9 @@ class SessionSurveyStoreTest {
         verify { observer(SessionFeedback.EMPTY) }
 
         val dummySessionFeedback = dummySessionFeedbackData()
-        dispatcher.dispatch(Action.SessionSurveyLoaded(dummySessionFeedback))
+        dispatcher.dispatch(
+            Action.SessionSurveyLoaded(dummySessionFeedback)
+        )
         verify { observer(dummySessionFeedback) }
     }
 }

--- a/feature/survey/src/test/java/io/github/droidkaigi/confsched2019/survey/ui/store/SessionSurveyStoreTest.kt
+++ b/feature/survey/src/test/java/io/github/droidkaigi/confsched2019/survey/ui/store/SessionSurveyStoreTest.kt
@@ -1,0 +1,45 @@
+package io.github.droidkaigi.confsched2019.survey.ui.store
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import io.github.droidkaigi.confsched2019.action.Action
+import io.github.droidkaigi.confsched2019.dispatcher.Dispatcher
+import io.github.droidkaigi.confsched2019.ext.android.CoroutinePlugin
+import io.github.droidkaigi.confsched2019.ext.android.changedForever
+import io.github.droidkaigi.confsched2019.model.LoadingState
+import io.github.droidkaigi.confsched2019.widget.component.DirectDispatcher
+import io.mockk.MockKAnnotations
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class SessionSurveyStoreTest {
+    @JvmField
+    @Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        CoroutinePlugin.mainDispatcherHandler = { DirectDispatcher }
+    }
+
+    @Test
+    fun loadingState() = runBlocking {
+        val dispatcher = Dispatcher()
+        val sessionSurveyStore = SessionSurveyStore(dispatcher)
+        val observer = mockk<(LoadingState?) -> Unit>(relaxed = true)
+
+        sessionSurveyStore.loadingState.changedForever(observer)
+        verify { observer(LoadingState.INITIALIZED) }
+
+        dispatcher.dispatch(Action.SessionSurveyLoadingStateChanged(LoadingState.LOADING))
+        verify { observer(LoadingState.LOADING) }
+
+        dispatcher.dispatch(Action.SessionSurveyLoadingStateChanged(LoadingState.LOADED))
+        verify { observer(LoadingState.LOADED) }
+    }
+}

--- a/feature/survey/src/test/java/io/github/droidkaigi/confsched2019/survey/ui/store/SessionSurveyStoreTest.kt
+++ b/feature/survey/src/test/java/io/github/droidkaigi/confsched2019/survey/ui/store/SessionSurveyStoreTest.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2019.survey.ui.store
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import io.github.droidkaigi.confsched2019.action.Action
 import io.github.droidkaigi.confsched2019.dispatcher.Dispatcher
+import io.github.droidkaigi.confsched2019.dummySessionFeedbackData
 import io.github.droidkaigi.confsched2019.ext.android.CoroutinePlugin
 import io.github.droidkaigi.confsched2019.ext.android.changedForever
 import io.github.droidkaigi.confsched2019.model.LoadingState
@@ -53,17 +54,7 @@ class SessionSurveyStoreTest {
         sessionSurveyStore.sessionFeedback.changedForever(observer)
         verify { observer(SessionFeedback.EMPTY) }
 
-        val dummySessionFeedback = SessionFeedback.EMPTY.copy(
-            "12345",
-            5,
-            4,
-            3,
-            2,
-            1,
-            "",
-            true
-        )
-
+        val dummySessionFeedback = dummySessionFeedbackData()
         dispatcher.dispatch(Action.SessionSurveyLoaded(dummySessionFeedback))
         verify { observer(dummySessionFeedback) }
     }

--- a/feature/survey/src/test/java/io/github/droidkaigi/confsched2019/survey/ui/store/SessionSurveyStoreTest.kt
+++ b/feature/survey/src/test/java/io/github/droidkaigi/confsched2019/survey/ui/store/SessionSurveyStoreTest.kt
@@ -6,6 +6,7 @@ import io.github.droidkaigi.confsched2019.dispatcher.Dispatcher
 import io.github.droidkaigi.confsched2019.ext.android.CoroutinePlugin
 import io.github.droidkaigi.confsched2019.ext.android.changedForever
 import io.github.droidkaigi.confsched2019.model.LoadingState
+import io.github.droidkaigi.confsched2019.model.SessionFeedback
 import io.github.droidkaigi.confsched2019.widget.component.DirectDispatcher
 import io.mockk.MockKAnnotations
 import io.mockk.mockk
@@ -41,5 +42,29 @@ class SessionSurveyStoreTest {
 
         dispatcher.dispatch(Action.SessionSurveyLoadingStateChanged(LoadingState.LOADED))
         verify { observer(LoadingState.LOADED) }
+    }
+
+    @Test
+    fun sessionFeedback() = runBlocking {
+        val dispatcher = Dispatcher()
+        val sessionSurveyStore = SessionSurveyStore(dispatcher)
+        val observer = mockk<(SessionFeedback) -> Unit>(relaxed = true)
+
+        sessionSurveyStore.sessionFeedback.changedForever(observer)
+        verify { observer(SessionFeedback.EMPTY) }
+
+        val dummySessionFeedback = SessionFeedback.EMPTY.copy(
+            "12345",
+            5,
+            4,
+            3,
+            2,
+            1,
+            "",
+            true
+        )
+
+        dispatcher.dispatch(Action.SessionSurveyLoaded(dummySessionFeedback))
+        verify { observer(dummySessionFeedback) }
     }
 }


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2019/issues/720

## Overview (Required)
- Add session survey store test

## Links
- SessionSurveyStore https://github.com/DroidKaigi/conference-app-2019/blob/master/feature/survey/src/main/java/io/github/droidkaigi/confsched2019/survey/ui/store/SessionSurveyStore.kt#L14

## Screenshot
<img src=https://user-images.githubusercontent.com/5681281/52172353-f8003000-27b0-11e9-86ef-a23e41e88b51.png width=700>

