### PR TITLE
Fix issue 755: Set background color white except SessionPagesFragment at navigation

### DIFF
--- a/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/MainActivity.kt
+++ b/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/MainActivity.kt
@@ -125,8 +125,10 @@ class MainActivity : DaggerAppCompatActivity() {
             // to avoid flickering, set current fragment background color to white
             // see https://github.com/DroidKaigi/conference-app-2019/pull/521
             supportFragmentManager.findFragmentById(R.id.root_nav_host_fragment)?.let { host ->
-                host.childFragmentManager
-                    .primaryNavigationFragment?.view?.setBackgroundColor(Color.WHITE)
+                val current = host.childFragmentManager.primaryNavigationFragment
+                if (current !is SessionPagesFragment) {
+                    current?.view?.setBackgroundColor(Color.WHITE)
+                }
             }
 
             val config = PageConfiguration.getConfiguration(destination.id)


### PR DESCRIPTION
## Issue
- close #755 

## Overview (Required)
- SessionPagesFragment has red background color, others has no background color (= transparent), then it looks flickering on navigating
- before implementation, it also changed background color of SessionPagesFragment

## Links
-

## Screenshot
Before | After
:--: | :--:
![before](https://user-images.githubusercontent.com/7608725/52174525-81772880-27d8-11e9-82d2-6ec80ac89e8a.gif) | ![after](https://user-images.githubusercontent.com/7608725/52174526-85a34600-27d8-11e9-9b8f-1787268430e1.gif)