### PR TITLE
[iOS] match tap and favorite behavior with android version

### DIFF
--- a/frontend/ios/DroidKaigi 2019/Scenes/Session/SessionTableViewCell.swift
+++ b/frontend/ios/DroidKaigi 2019/Scenes/Session/SessionTableViewCell.swift
@@ -28,13 +28,17 @@ class SessionTableViewCell: UITableViewCell, Reusable {
             remakeTimeAndRoomLabelConstraints()
             switch session {
             case let serviceSession as ServiceSession:
+                isUserInteractionEnabled = serviceSession.sessionType.supportDetail
                 titleLabel.text = serviceSession.title.getByLang(lang: LangKt.defaultLang())
+                favoriteButton.isHidden = !serviceSession.sessionType.isFavoritable
             case let speechSession as SpeechSession:
+                isUserInteractionEnabled = true
                 titleLabel.text = speechSession.title.getByLang(lang: LangKt.defaultLang())
                 speechSession.speakers.forEach { speaker in
                     let cell = SpeakerCell(speaker: speaker)
                     speakersStackView.addArrangedSubview(cell)
                 }
+                favoriteButton.isHidden = false
                 tagContents = speechSession.tagContents
             default:
                 return


### PR DESCRIPTION
## Issue
- None 🙇 

## Overview (Required)
- match tap action and showing favorite button behavior with android version


## Screenshot
Before | After
:--: | :--:
<img width="300" alt="2019-02-03 18 01 29" src="https://user-images.githubusercontent.com/952100/52174920-63acc200-27de-11e9-8252-327401ee1953.png"> | <img width="300" alt="2019-02-03 17 58 13" src="https://user-images.githubusercontent.com/952100/52174926-7626fb80-27de-11e9-9da7-60d9262b6937.png">

