### PR TITLE
Feature/issue550 add equalable content provider

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/EqualableContentsProvider.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/EqualableContentsProvider.kt
@@ -5,14 +5,19 @@ import java.util.Arrays
 interface EqualableContentsProvider {
     fun providerEqualableContents(): Array<*>
 
-    override fun equals(other: Any?): Boolean // equals()とhashCode()の実装を強制する
+    override fun equals(other: Any?): Boolean
 
     override fun hashCode(): Int
+
+    fun isTextHighlightNeedUpdate(): Boolean {
+        return false
+    }
 
     fun isSameContents(other: Any?): Boolean {
         other ?: return false
         if (other !is EqualableContentsProvider) return false
         if (other::class != this::class) return false
+        if (isTextHighlightNeedUpdate()) return false
         return other.providerEqualableContents().contentDeepEquals(this.providerEqualableContents())
     }
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/EqualableContentsProvider.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/EqualableContentsProvider.kt
@@ -1,0 +1,22 @@
+package io.github.droidkaigi.confsched2019.session.ui.item
+
+import java.util.Arrays
+
+interface EqualableContentsProvider {
+    fun providerEqualableContents(): Array<*>
+
+    override fun equals(other: Any?): Boolean // equals()とhashCode()の実装を強制する
+
+    override fun hashCode(): Int
+
+    fun isSameContents(other: Any?): Boolean {
+        other ?: return false
+        if (other !is EqualableContentsProvider) return false
+        if (other::class != this::class) return false
+        return other.providerEqualableContents().contentDeepEquals(this.providerEqualableContents())
+    }
+
+    fun contentsHash(): Int {
+        return Arrays.deepHashCode(arrayOf(this::class, this.providerEqualableContents()))
+    }
+}

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/ServiceSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/ServiceSessionItem.kt
@@ -19,7 +19,7 @@ class ServiceSessionItem @AssistedInject constructor(
     val sessionContentsActionCreator: SessionContentsActionCreator
 ) : BindableItem<ItemServiceSessionBinding>(
     session.id.hashCode().toLong()
-), SessionItem {
+), SessionItem, EqualableContentsProvider {
     val serviceSession get() = session
 
     @AssistedInject.Factory
@@ -63,18 +63,13 @@ class ServiceSessionItem @AssistedInject constructor(
 
     override fun getLayout(): Int = R.layout.item_service_session
 
+    override fun providerEqualableContents(): Array<*> = arrayOf(session)
+
     override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as ServiceSessionItem
-
-        if (session != other.session) return false
-
-        return true
+        return isSameContents(other)
     }
 
     override fun hashCode(): Int {
-        return session.hashCode()
+        return contentsHash()
     }
 }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/ServiceSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/ServiceSessionItem.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavDirections
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.xwray.groupie.databinding.BindableItem
+import io.github.droidkaigi.confsched2019.item.EqualableContentsProvider
 import io.github.droidkaigi.confsched2019.model.ServiceSession
 import io.github.droidkaigi.confsched2019.model.defaultLang
 import io.github.droidkaigi.confsched2019.session.R

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeakerItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeakerItem.kt
@@ -18,7 +18,8 @@ class SpeakerItem @AssistedInject constructor(
     @Assisted val clickNavDirection: NavDirections,
     @Assisted val query: String?,
     val navController: NavController
-) : BindableItem<ItemSpeakerBinding>(speaker.id.hashCode().toLong()) {
+) : BindableItem<ItemSpeakerBinding>(speaker.id.hashCode().toLong()),
+    EqualableContentsProvider {
     @AssistedInject.Factory
     interface Factory {
         fun create(
@@ -64,19 +65,13 @@ class SpeakerItem @AssistedInject constructor(
         }
     }
 
+    override fun providerEqualableContents(): Array<*> = arrayOf(speaker)
+
     override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as SpeakerItem
-
-        if (speaker != other.speaker) return false
-        if (query != other.query) return false
-
-        return true
+        return isSameContents(other)
     }
 
     override fun hashCode(): Int {
-        return speaker.hashCode() + query.hashCode()
+        return contentsHash()
     }
 }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeakerItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeakerItem.kt
@@ -8,6 +8,7 @@ import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.squareup.picasso.Picasso
 import com.xwray.groupie.databinding.BindableItem
+import io.github.droidkaigi.confsched2019.item.EqualableContentsProvider
 import io.github.droidkaigi.confsched2019.model.Speaker
 import io.github.droidkaigi.confsched2019.session.R
 import io.github.droidkaigi.confsched2019.session.databinding.ItemSpeakerBinding
@@ -68,7 +69,7 @@ class SpeakerItem @AssistedInject constructor(
     override fun providerEqualableContents(): Array<*> = arrayOf(speaker)
 
     override fun isTextHighlightNeedUpdate() = query?.let {
-        speaker.name.toLowerCase().contains(it.toLowerCase().toRegex())
+        speaker.name.toLowerCase().contains(it.toLowerCase())
     } ?: false
 
     override fun equals(other: Any?): Boolean {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeakerItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeakerItem.kt
@@ -67,6 +67,10 @@ class SpeakerItem @AssistedInject constructor(
 
     override fun providerEqualableContents(): Array<*> = arrayOf(speaker)
 
+    override fun isTextHighlightNeedUpdate() = query?.let {
+        speaker.name.toLowerCase().contains(it.toLowerCase().toRegex())
+    } ?: false
+
     override fun equals(other: Any?): Boolean {
         return isSameContents(other)
     }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
@@ -40,7 +40,7 @@ class SpeechSessionItem @AssistedInject constructor(
     val sessionContentsActionCreator: SessionContentsActionCreator
 ) : BindableItem<ItemSessionBinding>(
     session.id.hashCode().toLong()
-), SessionItem {
+), SessionItem, EqualableContentsProvider {
     val speechSession get() = session
 
     @AssistedInject.Factory
@@ -199,19 +199,13 @@ class SpeechSessionItem @AssistedInject constructor(
 
     override fun getLayout(): Int = R.layout.item_session
 
+    override fun providerEqualableContents(): Array<*> = arrayOf(session)
+
     override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as SpeechSessionItem
-
-        if (session != other.session) return false
-        if (query == null || other.query == null || query != other.query) return false
-
-        return true
+        return isSameContents(other)
     }
 
     override fun hashCode(): Int {
-        return session.hashCode() + query.hashCode()
+        return contentsHash()
     }
 }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
@@ -201,6 +201,17 @@ class SpeechSessionItem @AssistedInject constructor(
 
     override fun providerEqualableContents(): Array<*> = arrayOf(session)
 
+    override fun isTextHighlightNeedUpdate() = query?.let {
+        when {
+            session.title.getByLang(defaultLang()).toLowerCase()
+                .contains(query.toLowerCase().toRegex()) -> true
+            session.speakers.find {
+                it.name.toLowerCase().contains(query.toLowerCase().toRegex())
+            } != null -> true
+            else -> false
+        }
+    } ?: false
+
     override fun equals(other: Any?): Boolean {
         return isSameContents(other)
     }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeechSessionItem.kt
@@ -18,6 +18,7 @@ import com.squareup.inject.assisted.AssistedInject
 import com.squareup.picasso.Picasso
 import com.squareup.picasso.Target
 import com.xwray.groupie.databinding.BindableItem
+import io.github.droidkaigi.confsched2019.item.EqualableContentsProvider
 import io.github.droidkaigi.confsched2019.model.Speaker
 import io.github.droidkaigi.confsched2019.model.SpeechSession
 import io.github.droidkaigi.confsched2019.model.defaultLang
@@ -204,9 +205,9 @@ class SpeechSessionItem @AssistedInject constructor(
     override fun isTextHighlightNeedUpdate() = query?.let {
         when {
             session.title.getByLang(defaultLang()).toLowerCase()
-                .contains(query.toLowerCase().toRegex()) -> true
+                .contains(query.toLowerCase()) -> true
             session.speakers.find {
-                it.name.toLowerCase().contains(query.toLowerCase().toRegex())
+                it.name.toLowerCase().contains(query.toLowerCase())
             } != null -> true
             else -> false
         }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/TabularServiceSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/TabularServiceSessionItem.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavDirections
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import com.xwray.groupie.databinding.BindableItem
+import io.github.droidkaigi.confsched2019.item.EqualableContentsProvider
 import io.github.droidkaigi.confsched2019.model.ServiceSession
 import io.github.droidkaigi.confsched2019.model.defaultLang
 import io.github.droidkaigi.confsched2019.session.R

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/TabularServiceSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/TabularServiceSessionItem.kt
@@ -17,7 +17,7 @@ class TabularServiceSessionItem @AssistedInject constructor(
     private val navController: NavController
 ) : BindableItem<ItemTabularServiceSessionBinding>(
     session.id.hashCode().toLong()
-), SessionItem {
+), SessionItem, EqualableContentsProvider {
 
     @AssistedInject.Factory
     interface Factory {
@@ -46,18 +46,13 @@ class TabularServiceSessionItem @AssistedInject constructor(
 
     override fun getLayout() = R.layout.item_tabular_service_session
 
+    override fun providerEqualableContents(): Array<*> = arrayOf(session)
+
     override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as TabularServiceSessionItem
-
-        if (session != other.session) return false
-
-        return true
+        return isSameContents(other)
     }
 
     override fun hashCode(): Int {
-        return session.hashCode()
+        return contentsHash()
     }
 }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/TabularSpeechSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/TabularSpeechSessionItem.kt
@@ -12,6 +12,7 @@ import com.squareup.picasso.Picasso
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.databinding.BindableItem
 import com.xwray.groupie.databinding.ViewHolder
+import io.github.droidkaigi.confsched2019.item.EqualableContentsProvider
 import io.github.droidkaigi.confsched2019.model.Speaker
 import io.github.droidkaigi.confsched2019.model.SpeechSession
 import io.github.droidkaigi.confsched2019.model.defaultLang

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/TabularSpeechSessionItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/TabularSpeechSessionItem.kt
@@ -26,7 +26,7 @@ class TabularSpeechSessionItem @AssistedInject constructor(
     private val navController: NavController
 ) : BindableItem<ItemTabularSpeechSessionBinding>(
     session.id.hashCode().toLong()
-), SessionItem {
+), SessionItem, EqualableContentsProvider {
 
     @AssistedInject.Factory
     interface Factory {
@@ -82,19 +82,14 @@ class TabularSpeechSessionItem @AssistedInject constructor(
 
     override fun getLayout() = R.layout.item_tabular_speech_session
 
+    override fun providerEqualableContents(): Array<*> = arrayOf(session)
+
     override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as TabularSpeechSessionItem
-
-        if (session != other.session) return false
-
-        return true
+        return isSameContents(other)
     }
 
     override fun hashCode(): Int {
-        return session.hashCode()
+        return contentsHash()
     }
 
     private class SpeakerIconItem(

--- a/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/item/EqualableContentsProvider.kt
+++ b/frontendcomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/item/EqualableContentsProvider.kt
@@ -1,4 +1,4 @@
-package io.github.droidkaigi.confsched2019.session.ui.item
+package io.github.droidkaigi.confsched2019.item
 
 import java.util.Arrays
 
@@ -18,6 +18,7 @@ interface EqualableContentsProvider {
         if (other !is EqualableContentsProvider) return false
         if (other::class != this::class) return false
         if (isTextHighlightNeedUpdate()) return false
+        if (other.isTextHighlightNeedUpdate()) return false
         return other.providerEqualableContents().contentDeepEquals(this.providerEqualableContents())
     }
 


### PR DESCRIPTION
## Issue
- close #550 

## Overview (Required)
- Added EqualableContentsProvider to check content is equal or not
- If text highlight is needed, update item 

## Links
- https://qiita.com/takahirom/items/4125d7c871fad534d3c2#%E5%A4%89%E6%9B%B4%E3%82%A2%E3%83%8B%E3%83%A1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E5%95%8F%E9%A1%8C-equals--hashcode%E3%82%92%E7%84%A1%E7%90%86%E3%81%AA%E3%81%8F%E5%AE%9F%E8%A3%85%E3%81%99%E3%82%8B

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1386930/51435244-9c18b000-1cb6-11e9-90f9-dae2ae604c6a.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/21967922/52175722-6d88f200-27eb-11e9-9c94-bc4c124c3e86.gif" width="300" />
