### PR TITLE
Dismiss warning 'Ignored files found that are tracked'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,6 @@ bundletool.jar
 dpg
 toc.pb
 *.keystore
+!frontend/android/debug.keystore
 .transart/
 transart


### PR DESCRIPTION
## Issue
- Following warning is shown when opening the project.
<img width="369" alt="ignored files found that are tracked" src="https://user-images.githubusercontent.com/1378923/52176418-eb51fb00-27f5-11e9-81ea-f256479497ce.png">

- Because `*.keystore` is listed in `.gitignore`, but `frontend/android/debug.keystore` is tracked.


## Overview (Required)
- Exclude `frontend/android/debug.keystore` from ignored files by `.gitignore`.
