### PR TITLE
Expand BottomSheetFragments(collapsed) when on Back Key Pressed.

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -46,7 +46,7 @@ object Dep {
         val coreKtx = "androidx.core:core-ktx:1.0.0-alpha1"
         val preference = "androidx.preference:preference:1.0.0"
         val browser = "androidx.browser:browser:1.0.0"
-        val fragment =  "androidx.fragment:fragment:1.1.0-alpha03"
+        val fragment = "androidx.fragment:fragment:1.1.0-alpha03"
 
         val lifecycleExtensions = "androidx.lifecycle:lifecycle-extensions:2.0.0"
         val lifecycleLiveData = "androidx.lifecycle:lifecycle-livedata:2.0.0"

--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -46,6 +46,7 @@ object Dep {
         val coreKtx = "androidx.core:core-ktx:1.0.0-alpha1"
         val preference = "androidx.preference:preference:1.0.0"
         val browser = "androidx.browser:browser:1.0.0"
+        val fragment =  "androidx.fragment:fragment:1.1.0-alpha03"
 
         val lifecycleExtensions = "androidx.lifecycle:lifecycle-extensions:2.0.0"
         val lifecycleLiveData = "androidx.lifecycle:lifecycle-livedata:2.0.0"

--- a/feature/session/build.gradle
+++ b/feature/session/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation Dep.Kotlin.androidCoroutinesDispatcher
 
     implementation Dep.AndroidX.appCompat
+    implementation Dep.AndroidX.fragment
     implementation Dep.AndroidX.constraint
     implementation Dep.AndroidX.recyclerView
     api Dep.AndroidX.emoji

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetDaySessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetDaySessionsFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
 import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.RecyclerView
@@ -61,6 +62,15 @@ class BottomSheetDaySessionsFragment : DaggerFragment() {
 
     private val args: BottomSheetDaySessionsFragmentArgs by lazy {
         BottomSheetDaySessionsFragmentArgs.fromBundle(arguments ?: Bundle())
+    }
+
+    private val onBackPressedListener = OnBackPressedCallback {
+        if (binding.isCollapsed == true) {
+            sessionPageActionCreator.toggleFilterExpanded(SessionPage.pageOfDay(args.day))
+            true
+        } else {
+            false
+        }
     }
 
     override fun onCreateView(
@@ -159,6 +169,16 @@ class BottomSheetDaySessionsFragment : DaggerFragment() {
                 scrollToCurrentSession()
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        activity?.addOnBackPressedCallback(onBackPressedListener)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        activity?.removeOnBackPressedCallback(onBackPressedListener)
     }
 
     override fun onDestroyView() {

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetFavoriteSessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetFavoriteSessionsFragment.kt
@@ -64,6 +64,15 @@ class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
     private val groupAdapter
         get() = binding.sessionsRecycler.adapter as GroupAdapter<*>
 
+    private val onBackPressedListener = {
+        if (binding.isCollapsed == true) {
+            sessionPageActionCreator.toggleFilterExpanded(SessionPage.Favorite)
+            true
+        } else {
+            false
+        }
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -153,6 +162,16 @@ class BottomSheetFavoriteSessionsFragment : DaggerFragment() {
                 binding.isCollapsed = isCollapsed
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        activity?.addOnBackPressedCallback(onBackPressedListener)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        activity?.removeOnBackPressedCallback(onBackPressedListener)
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION


## Issue
- None

## Overview (Required)
- When BottomSheetDaySessionsFragment / BottomSheetFavoriteSessionsFragment is collapsed, pressing the back-key closed the application and it was not intuitive, so I tried to expand it pressing back-key.
- Apply androidx.fragment for using easy onBackKeyPress handling in fragment. But 1.1.0-alpha03 haha :)

## Links
- http://androhi.hatenablog.com/entry/2019/01/31/201235

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1821958/52178508-e51e4780-2812-11e9-8392-abc26f5323fc.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/1821958/52178512-f23b3680-2812-11e9-8a11-ece0451dc921.gif" width="300" />
