### PR TITLE
Fix crash bug in highlighting text

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/TextViewBinding.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/TextViewBinding.kt
@@ -20,7 +20,8 @@ fun setHighlightText(view: TextView, highlightText: String?) {
         view.text = stringBuilder
         return
     }
-    val pattern = Pattern.compile(highlightText, Pattern.CASE_INSENSITIVE)
+    val quotedHighlightText = Pattern.quote(highlightText)
+    val pattern = Pattern.compile(quotedHighlightText, Pattern.CASE_INSENSITIVE)
     val matcher = pattern.matcher(view.text)
     while (matcher.find()) {
         stringBuilder.setSpan(


### PR DESCRIPTION

## Issue
- close #768

## Overview (Required)
- Quote input `highlightText` with `Pattern.quote()`

## Links
- https://docs.oracle.com/javase/jp/8/docs/api/java/util/regex/Pattern.html#quote-java.lang.String-

## Screenshot

<img src="https://user-images.githubusercontent.com/1014477/52178700-0849f680-2815-11e9-8537-be605e0c70ea.gif" width="300">