### PR TITLE
Remove NavigationBar Bottom Line for iOS

### DIFF
--- a/frontend/ios/DroidKaigi 2019/AppDelegate.swift
+++ b/frontend/ios/DroidKaigi 2019/AppDelegate.swift
@@ -45,6 +45,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UINavigationBar.appearance().barTintColor = UIColor.DK.primary.color
         UINavigationBar.appearance().barStyle = .black
         UINavigationBar.appearance().isTranslucent = false
+        UINavigationBar.appearance().setBackgroundImage(UIImage(), for: .default)
+        UINavigationBar.appearance().shadowImage = UIImage()
     }
 }
 


### PR DESCRIPTION
## Overview (Required)
- remove `UINavigationBar` bottom line

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/12663296/52180144-d68d5b80-2825-11e9-9fce-359bd0368414.png" width="300" /> | <img src="https://user-images.githubusercontent.com/12663296/52180149-e3aa4a80-2825-11e9-9cd1-633c02cb961d.png" width="300" />

