### PR TITLE
feat: SharedElement Transition for SpeakerIcon

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SpeakerFragment.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched2019.session.ui
 
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
+import android.transition.TransitionInflater
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -17,6 +18,7 @@ import io.github.droidkaigi.confsched2019.ext.android.changed
 import io.github.droidkaigi.confsched2019.model.defaultLang
 import io.github.droidkaigi.confsched2019.session.R
 import io.github.droidkaigi.confsched2019.session.databinding.FragmentSpeakerBinding
+import io.github.droidkaigi.confsched2019.session.ui.bindingadapter.ImageLoadListener
 import io.github.droidkaigi.confsched2019.session.ui.store.SessionContentsStore
 import io.github.droidkaigi.confsched2019.session.ui.widget.DaggerFragment
 import javax.inject.Inject
@@ -49,6 +51,15 @@ class SpeakerFragment : DaggerFragment() {
         val speakerId = speakerFragmentArgs.speaker
         binding.lang = defaultLang()
         binding.timeZoneOffset = DateTimeSpan(hours = 9) // FIXME Get from device setting
+        binding.listener = object : ImageLoadListener {
+            override fun onImageLoaded() {
+                startPostponedEnterTransition()
+            }
+
+            override fun onImageLoadFailed() {
+                startPostponedEnterTransition()
+            }
+        }
         sessionContentsStore.speaker(speakerId).changed(
             this
         ) { speaker ->
@@ -66,6 +77,9 @@ class SpeakerFragment : DaggerFragment() {
                 )
             )
         }
+        sharedElementEnterTransition =
+            TransitionInflater.from(context).inflateTransition(R.transition.speaker_shared_enter)
+        postponeEnterTransition()
     }
 }
 

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SpeakerFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/SpeakerFragment.kt
@@ -10,6 +10,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavController
+import android.transition.Fade
 import com.soywiz.klock.DateTimeSpan
 import dagger.Module
 import dagger.Provides
@@ -79,6 +80,8 @@ class SpeakerFragment : DaggerFragment() {
         }
         sharedElementEnterTransition =
             TransitionInflater.from(context).inflateTransition(R.transition.speaker_shared_enter)
+        enterTransition = Fade()
+        returnTransition = null
         postponeEnterTransition()
     }
 }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/ImageViewBinding.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/ImageViewBinding.kt
@@ -4,6 +4,7 @@ import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.databinding.BindingAdapter
+import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
 import jp.wasabeef.picasso.transformations.CropCircleTransformation
 
@@ -15,7 +16,8 @@ fun loadImage(imageView: ImageView, imageUrl: String?) {
         imageUrl = imageUrl,
         circleCrop = false,
         rawPlaceHolder = null,
-        placeHolderTint = null
+        placeHolderTint = null,
+        listener = null
     )
 }
 
@@ -33,6 +35,33 @@ fun loadImage(
     circleCrop: Boolean?,
     rawPlaceHolder: Drawable?,
     placeHolderTint: Int?
+) {
+    loadImage(
+        imageView = imageView,
+        imageUrl = imageUrl,
+        circleCrop = circleCrop,
+        rawPlaceHolder = rawPlaceHolder,
+        placeHolderTint = placeHolderTint,
+        listener = null
+    )
+}
+
+@BindingAdapter(
+    value = [
+        "imageUrl",
+        "circleCrop",
+        "placeHolder",
+        "placeHolderTint",
+        "listener"
+    ]
+)
+fun loadImage(
+    imageView: ImageView,
+    imageUrl: String?,
+    circleCrop: Boolean?,
+    rawPlaceHolder: Drawable?,
+    placeHolderTint: Int?,
+    listener: ImageLoadListener?
 ) {
     val placeHolder = run {
         DrawableCompat.wrap(
@@ -56,5 +85,21 @@ fun loadImage(
                 placeholder(placeHolder)
             }
         }
-        .into(imageView)
+        .into(imageView, object : Callback {
+            override fun onSuccess() {
+                listener?.onImageLoaded()
+            }
+
+            override fun onError(e: Exception?) {
+                listener?.onImageLoadFailed()
+            }
+        })
+}
+
+/**
+ * An interface for responding to image loading completion.
+ */
+interface ImageLoadListener {
+    fun onImageLoaded()
+    fun onImageLoadFailed()
 }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeakerItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeakerItem.kt
@@ -64,7 +64,7 @@ class SpeakerItem @AssistedInject constructor(
             navController.navigate(
                 clickNavDirection,
                 FragmentNavigatorExtras(
-                    itemBinding.speakerImage to it.context.getString(R.string.speaker_image_transition)
+                    itemBinding.speakerImage to speaker.id
                 )
             )
         }

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeakerItem.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/item/SpeakerItem.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2019.session.ui.item
 import androidx.core.content.ContextCompat
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
+import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
@@ -60,7 +61,12 @@ class SpeakerItem @AssistedInject constructor(
         }
 
         itemBinding.root.setOnClickListener {
-            navController.navigate(clickNavDirection)
+            navController.navigate(
+                clickNavDirection,
+                FragmentNavigatorExtras(
+                    itemBinding.speakerImage to it.context.getString(R.string.speaker_image_transition)
+                )
+            )
         }
     }
 

--- a/feature/session/src/main/res/layout/fragment_speaker.xml
+++ b/feature/session/src/main/res/layout/fragment_speaker.xml
@@ -26,6 +26,12 @@
             name="timeZoneOffset"
             type="com.soywiz.klock.DateTimeSpan"
             />
+
+        <variable
+            name="listener"
+            type="io.github.droidkaigi.confsched2019.session.ui.bindingadapter.ImageLoadListener"
+            />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -87,9 +93,11 @@
                     android:layout_margin="16dp"
                     android:contentDescription="@string/speaker_label"
                     app:circleCrop="@{true}"
+                    android:transitionName="@string/speaker_image_transition"
                     app:imageUrl="@{speaker.imageUrl}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
+                    app:listener="@{listener}"
                     app:placeHolder="@{@drawable/ic_person_outline_black_24dp}"
                     app:placeHolderTint="@{@color/gray2}"
                     tools:src="@tools:sample/avatars"

--- a/feature/session/src/main/res/layout/fragment_speaker.xml
+++ b/feature/session/src/main/res/layout/fragment_speaker.xml
@@ -93,7 +93,7 @@
                     android:layout_margin="16dp"
                     android:contentDescription="@string/speaker_label"
                     app:circleCrop="@{true}"
-                    android:transitionName="@string/speaker_image_transition"
+                    android:transitionName="@{speaker.id}"
                     app:imageUrl="@{speaker.imageUrl}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="parent"

--- a/feature/session/src/main/res/layout/item_speaker.xml
+++ b/feature/session/src/main/res/layout/item_speaker.xml
@@ -11,9 +11,11 @@
             name="speaker"
             type="io.github.droidkaigi.confsched2019.model.Speaker"
             />
+
         <variable
             name="query"
-            type="String" />
+            type="String"
+            />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -31,6 +33,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginTop="8dp"
             android:contentDescription="@string/session_detail_speaker"
+            android:transitionName="@string/speaker_image_transition"
             app:circleCrop="@{true}"
             app:imageUrl="@{speaker.imageUrl}"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -50,11 +53,11 @@
             android:text="@{speaker.name}"
             android:textAppearance="@style/TextAppearance.Lekton.Body1"
             android:textColor="@color/gray1"
+            app:highlightText="@{query}"
             app:layout_constraintBottom_toBottomOf="@id/speaker_image"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/speaker_image"
             app:layout_constraintTop_toTopOf="@id/speaker_image"
-            app:highlightText="@{query}"
             tools:text="@tools:sample/full_names"
             />
 

--- a/feature/session/src/main/res/layout/item_speaker.xml
+++ b/feature/session/src/main/res/layout/item_speaker.xml
@@ -33,7 +33,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginTop="8dp"
             android:contentDescription="@string/session_detail_speaker"
-            android:transitionName="@string/speaker_image_transition"
+            android:transitionName="@{speaker.id}"
             app:circleCrop="@{true}"
             app:imageUrl="@{speaker.imageUrl}"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/frontendcomponent/androidcomponent/src/main/res/transition/speaker_shared_enter.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/transition/speaker_shared_enter.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<transitionSet>
+    <changeBounds/>
+    <changeTransform/>
+    <changeClipBounds/>
+    <changeImageTransform/>
+</transitionSet>

--- a/frontendcomponent/androidcomponent/src/main/res/values/strings.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values/strings.xml
@@ -34,4 +34,6 @@
     <string name="notification_message_session_start_time">%1$s to %2$s @ %3$s</string>
     <!-- Tabular Form -->
     <string name="tabular_form_label">Timetable</string>
+
+    <string name="speaker_image_transition" translatable="false">speaker_image</string>
 </resources>

--- a/frontendcomponent/androidcomponent/src/main/res/values/strings.xml
+++ b/frontendcomponent/androidcomponent/src/main/res/values/strings.xml
@@ -34,6 +34,4 @@
     <string name="notification_message_session_start_time">%1$s to %2$s @ %3$s</string>
     <!-- Tabular Form -->
     <string name="tabular_form_label">Timetable</string>
-
-    <string name="speaker_image_transition" translatable="false">speaker_image</string>
 </resources>


### PR DESCRIPTION
## Issue
- close #185

## Overview (Required)
- SharedElement Transition for Speaker Icon from (Session Detail/Search) Screen to Speaker Screen
- We may consider about NON SharedElement Transition for Speaker Icon
  - It looks that non SharedElements appear soon and Speaker Icon moves on them.
- There is no transition when back from Speaker Screen
  - I need more investigation

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1014262/52186423-9dc3a580-286a-11e9-8cb3-b1c08f2ed3e9.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/1014262/52186424-9e5c3c00-286a-11e9-9908-34063d6554e5.gif" width="300" />
