### PR TITLE
Add versionCode offset to avoid accidental versionCode duplication 

### DIFF
--- a/buildSrc/src/main/java/dependencies/Versions.kt
+++ b/buildSrc/src/main/java/dependencies/Versions.kt
@@ -7,7 +7,9 @@ private object Versions {
     private val versionMajor = 1
     private val versionMinor = 0
     private val versionPatch = 1
-    val androidVersionCode = versionMajor * 10000 + versionMinor * 100 + versionPatch
+    private val versionOffset = 0
+    val androidVersionCode =
+        (versionMajor * 10000 + versionMinor * 100 + versionPatch) * 100 + versionOffset
 
     val androidVersionName = "$versionMajor.$versionMinor.$versionPatch"
 }


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- PlayStore cannot accept the same versionCode once we upload so I've added versionCode offset which is kinda *reserved* version space.