### PR TITLE
Avoid IndexOutOfBoundsException at RecyclerView.getChildAdapterPosition

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/TimetableCurrentTimeLineDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/TimetableCurrentTimeLineDecoration.kt
@@ -59,12 +59,7 @@ open class TimetableCurrentTimeLineDecoration(
 
     protected fun calcLineHeight(parent: RecyclerView, currentTime: Long): Float {
         val originView = parent.getChildAt(0) ?: return 0F
-        val childAdapterPosition = parent.getChildAdapterPosition(originView)
-        if (childAdapterPosition == RecyclerView.NO_POSITION) {
-            return 0F
-        }
-
-        val originStartUnixMillis = groupAdapter.getItem(childAdapterPosition)
+        val originStartUnixMillis = groupAdapter.getItem(parent.getChildAdapterPosition(originView))
             .startUnixMillis
 
         val gapHeight = TimeUnit.MILLISECONDS

--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/TimetableCurrentTimeLineDecoration.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/TimetableCurrentTimeLineDecoration.kt
@@ -58,8 +58,13 @@ open class TimetableCurrentTimeLineDecoration(
         }
 
     protected fun calcLineHeight(parent: RecyclerView, currentTime: Long): Float {
-        val originView = parent.getChildAt(0)
-        val originStartUnixMillis = groupAdapter.getItem(parent.getChildAdapterPosition(originView))
+        val originView = parent.getChildAt(0) ?: return 0F
+        val childAdapterPosition = parent.getChildAdapterPosition(originView)
+        if (childAdapterPosition == RecyclerView.NO_POSITION) {
+            return 0F
+        }
+
+        val originStartUnixMillis = groupAdapter.getItem(childAdapterPosition)
             .startUnixMillis
 
         val gapHeight = TimeUnit.MILLISECONDS


### PR DESCRIPTION
## Issue
- ref #794 

## Overview (Required)
- Avoid IndexOutOfBoundsException when access RecyclerView.getChildAdapterPosition.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/17231507/52247583-cc568480-292d-11e9-8896-d22a08f97a5f.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/17231507/52250652-324a0880-293c-11e9-9aa7-041675403fa4.gif" width="300" />
