### PR TITLE
Change app name for non-release builds.

### DIFF
--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -47,12 +47,14 @@ android {
             if (isCi || isReleaseBuild) {
                 applicationIdSuffix Packages.debugNameSuffix
             }
+            manifestPlaceholders = [appName: "@string/app_name_debug"]
             debuggable true
         }
         staging {
             if (isCi || isReleaseBuild) {
                 applicationIdSuffix Packages.debugNameSuffix
             }
+            manifestPlaceholders = [appName: "@string/app_name_staging"]
             debuggable true
             zipAlignEnabled true
             signingConfig = signingConfigs.debug
@@ -70,6 +72,7 @@ android {
             }
         }
         release {
+            manifestPlaceholders = [appName: "@string/app_name"]
             debuggable false
             zipAlignEnabled true
             signingConfig = signingConfigs.release

--- a/frontend/android/src/debug/res/values/string.xml
+++ b/frontend/android/src/debug/res/values/string.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name_debug" translatable="false">DK2019 Debug</string>
+</resources>

--- a/frontend/android/src/main/AndroidManifest.xml
+++ b/frontend/android/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         android:name=".App"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="${appName}"
         android:supportsRtl="false"
         android:theme="@style/AppTheme"
         >

--- a/frontend/android/src/staging/res/values/string.xml
+++ b/frontend/android/src/staging/res/values/string.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name_staging" translatable="false">DK2019 Staging</string>
+</resources>


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- Current app has same name for debug/staging builds and release build, but their package name is not same. In launcher app screen, we cannot identify which is debug/staging/release build.

## Links
-

## Screenshot
Build | Before | After
:--: |:--: | :--:
Debug | <img src="https://user-images.githubusercontent.com/10704349/52354698-42650380-2a74-11e9-9317-ca69a95dab5e.png" width="300" /> | <img src="https://user-images.githubusercontent.com/10704349/52354700-42650380-2a74-11e9-8dcb-918396182ce7.png" width="300" />
Staging | <img src="https://user-images.githubusercontent.com/10704349/52354698-42650380-2a74-11e9-9317-ca69a95dab5e.png" width="300" /> | <img src="https://user-images.githubusercontent.com/10704349/52354699-42650380-2a74-11e9-9f96-51fc47194734.png" width="300" />