### PR TITLE
fix timetable relayout

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/TimetableLayoutManager.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/widget/TimetableLayoutManager.kt
@@ -102,10 +102,10 @@ class TimetableLayoutManager(
             return
         }
 
-        anchor.reset()
         calculateColumns()
 
         pendingScrollPosition?.let {
+            anchor.reset()
             detachAndScrapAttachedViews(recycler)
             val period = periods[it]
             relayoutChildren(parentLeft, parentTop, period, recycler)
@@ -116,8 +116,9 @@ class TimetableLayoutManager(
         val firstVisibleView = findFirstVisibleView()
         val offsetX = saveState?.left ?: firstVisibleView?.let(this::getDecoratedLeft)
         val offsetY = saveState?.top ?: firstVisibleView?.let(this::getDecoratedTop)
-        val period = (saveState?.position ?: firstVisibleView?.adapterPosition)
-            ?.let(periods::getOrNull)
+        val period =
+            (saveState?.position ?: anchor.top.get(anchor.leftColumn, -1)).let(periods::getOrNull)
+        anchor.reset()
         detachAndScrapAttachedViews(recycler)
         if (offsetX != null && offsetY != null && period != null)
             relayoutChildren(offsetX, offsetY, period, recycler)


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
sometimes View#adapterPosition returns `-1`. So TimetableLayoutManager can not relayout correctly.
use Anchor#top instead of View#adapterPosition