### PR TITLE
fix: cannot open speaker screen which no speaker image

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/ImageViewBinding.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/bindingadapter/ImageViewBinding.kt
@@ -72,6 +72,7 @@ fun loadImage(
     }
     imageUrl ?: run {
         imageView.setImageDrawable(placeHolder)
+        listener?.onImageLoaded()
     }
 
     Picasso


### PR DESCRIPTION
## Overview (Required)
- Cannot open Speaker screen which there is no speaker image
- It is because that Speaker screen wait for loading speaker image for the purpose of SharedElement transition, but there is no speaker image.

## Links
https://twitter.com/Pooh3Mobi/status/1093264420090785792

## Screenshot
<img src="https://user-images.githubusercontent.com/1014262/52382018-0f902f00-2ab7-11e9-8de0-11e056d8263c.gif" width="300" />
