### PR TITLE
Fix current scroll logic

### DIFF
--- a/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetDaySessionsFragment.kt
+++ b/feature/session/src/main/java/io/github/droidkaigi/confsched2019/session/ui/BottomSheetDaySessionsFragment.kt
@@ -187,9 +187,13 @@ class BottomSheetDaySessionsFragment : DaggerFragment() {
     }
 
     private fun scrollToCurrentSession() {
+        val targetSession = sessionPagesStore.filteredSessions.value.orEmpty()
+            .filter { session -> session.isOnGoing }
+            .distinctBy { session -> session.startTime }
+            .lastOrNull()
         val position = sessionPagesStore.filteredSessions.value.orEmpty()
             .filter { session -> session.dayNumber == args.day }
-            .indexOfFirst { session -> session.isOnGoing }
+            .indexOf(targetSession)
         binding.sessionsRecycler.scrollToPosition(position)
     }
 


### PR DESCRIPTION
## Issue
- close #819 

## Overview (Required)
- The target session is "the first of sessions that are on going" now.
- When some long sessions(for example Code Labs), are on going, this logic is non-intuitive.
- So I changed the logic to below.
  - Filter `on going`
  - Delete sessions `start time is duplicated`
  - Get last session
  - Get the session's position in the displayed list
  - Scroll

## Links
- none

## Screenshot
The time of the device was set 2019/02/07 16:05
 <img src="https://user-images.githubusercontent.com/26807657/52536528-25e00880-2d9f-11e9-9644-2b1bab98728c.gif" width="300" />
