### PR TITLE
Add setting feature with checkbox

### DIFF
--- a/buildSrc/src/main/java/dependencies/Dep.kt
+++ b/buildSrc/src/main/java/dependencies/Dep.kt
@@ -3,7 +3,7 @@ package dependencies
 @Suppress("unused")
 object Dep {
     object GradlePlugin {
-        val android = "com.android.tools.build:gradle:3.4.0-beta03"
+        val android = "com.android.tools.build:gradle:3.4.0-beta05"
         val r8 = "com.android.tools:r8:1.3.52"
         val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Kotlin.version}"
         val kotlinSerialization = "org.jetbrains.kotlin:kotlin-serialization:${Kotlin.version}"

--- a/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/action/Action.kt
+++ b/corecomponent/androidcomponent/src/main/java/io/github/droidkaigi/confsched2019/action/Action.kt
@@ -92,4 +92,6 @@ sealed class Action {
     data class SessionSurveyLoaded(val sessionFeedback: SessionFeedback) : Action()
 
     class FloorMapLoadingStateChanged(val loadingState: LoadingState) : Action()
+
+    data class SettingContentsChanged(val contents : MutableMap<String, Boolean>) : Action()
 }

--- a/feature/about/build.gradle
+++ b/feature/about/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     testImplementation Dep.Test.junit
     androidTestImplementation Dep.Test.testRunner
     androidTestImplementation Dep.Test.espressoCore
+    compile project(path: ':feature:system')
 }
 
 static def getCommitHash() {

--- a/feature/about/src/main/java/io/github/droidkaigi/confsched2019/about/ui/AboutFragment.kt
+++ b/feature/about/src/main/java/io/github/droidkaigi/confsched2019/about/ui/AboutFragment.kt
@@ -13,10 +13,10 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.ViewHolder
 import dagger.Module
 import dagger.Provides
+import dagger.android.support.DaggerFragment
 import io.github.droidkaigi.confsched2019.about.R
 import io.github.droidkaigi.confsched2019.about.databinding.FragmentAboutBinding
 import io.github.droidkaigi.confsched2019.about.ui.item.AboutSection
-import io.github.droidkaigi.confsched2019.about.ui.widget.DaggerFragment
 import io.github.droidkaigi.confsched2019.about.ui.widget.DottedItemDecoration
 import io.github.droidkaigi.confsched2019.di.PageScope
 import io.github.droidkaigi.confsched2019.ext.changed

--- a/feature/settings/src/main/java/io/github/droidkaigi/confsched2019/settings/ui/DaggerFragment.kt
+++ b/feature/settings/src/main/java/io/github/droidkaigi/confsched2019/settings/ui/DaggerFragment.kt
@@ -1,7 +1,8 @@
-package io.github.droidkaigi.confsched2019.about.ui.widget
+package io.github.droidkaigi.confsched2019.settings.ui
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceFragmentCompat
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.support.AndroidSupportInjection

--- a/feature/settings/src/main/java/io/github/droidkaigi/confsched2019/settings/ui/PreferenceActionCreator.kt
+++ b/feature/settings/src/main/java/io/github/droidkaigi/confsched2019/settings/ui/PreferenceActionCreator.kt
@@ -1,0 +1,20 @@
+package io.github.droidkaigi.confsched2019.settings.ui
+
+import io.github.droidkaigi.confsched2019.action.Action
+import io.github.droidkaigi.confsched2019.dispatcher.Dispatcher
+import io.github.droidkaigi.confsched2019.model.SettingContents
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import javax.inject.Inject
+
+class PreferenceActionCreator @Inject constructor(
+    val dispatcher: Dispatcher)
+    : CoroutineScope by GlobalScope + SupervisorJob() {
+    fun submit(action: Action)=launch {
+        dispatcher.dispatch(action)
+
+    }
+}

--- a/feature/settings/src/main/java/io/github/droidkaigi/confsched2019/settings/ui/SettingsFragment.kt
+++ b/feature/settings/src/main/java/io/github/droidkaigi/confsched2019/settings/ui/SettingsFragment.kt
@@ -1,11 +1,95 @@
 package io.github.droidkaigi.confsched2019.settings.ui
 
+import android.content.Context
+import android.content.SharedPreferences
 import android.os.Bundle
-import androidx.preference.PreferenceFragmentCompat
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CheckBox
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import dagger.Module
+import dagger.Provides
+import io.github.droidkaigi.confsched2019.di.PageScope
+import io.github.droidkaigi.confsched2019.model.SettingContents
 import io.github.droidkaigi.confsched2019.settings.R
+import java.lang.RuntimeException
+import javax.inject.Inject
 
-class SettingsFragment : PreferenceFragmentCompat() {
-    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
-        setPreferencesFromResource(R.xml.preferences, rootKey)
+class SettingsFragment : Fragment() {
+
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.settings_fragment, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val sessionTitleValue = android.preference.PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SESSION_TITLE, false)
+        val sessionUrlValue = android.preference.PreferenceManager.getDefaultSharedPreferences(context).getBoolean(SESSION_URL, false)
+        val eventHashtagValue = android.preference.PreferenceManager.getDefaultSharedPreferences(context).getBoolean(EVENT_HUSHTAG, false)
+        val roomHashtagValue = android.preference.PreferenceManager.getDefaultSharedPreferences(context).getBoolean(ROOM_HUSHTAG, false)
+
+        val settingContents = SettingContents()
+        settingContents.preferences[SESSION_TITLE] = sessionTitleValue
+        settingContents.preferences[SESSION_URL] = sessionUrlValue
+        settingContents.preferences[EVENT_HUSHTAG] = eventHashtagValue
+        settingContents.preferences[ROOM_HUSHTAG] = roomHashtagValue
+
+        view.findViewById<CheckBox>(io.github.droidkaigi.confsched2019.settings.R.id.session_title_key).isChecked = settingContents.preferences[SESSION_TITLE]!!
+        view.findViewById<CheckBox>(io.github.droidkaigi.confsched2019.settings.R.id.session_title_key).setOnCheckedChangeListener { buttonView, isChecked ->
+            android.preference.PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putBoolean(SESSION_TITLE,isChecked)
+                .apply()
+        }
+        view.findViewById<CheckBox>(io.github.droidkaigi.confsched2019.settings.R.id.session_url_key).isChecked = settingContents.preferences [SESSION_URL]!!
+        view.findViewById<CheckBox>(io.github.droidkaigi.confsched2019.settings.R.id.session_url_key).setOnCheckedChangeListener { buttonView, isChecked ->
+            android.preference.PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putBoolean(SESSION_URL, isChecked)
+                .apply()
+        }
+
+        view.findViewById<CheckBox>(io.github.droidkaigi.confsched2019.settings.R.id.event_hashtag_key).isChecked = settingContents.preferences [EVENT_HUSHTAG]!!
+        view.findViewById<CheckBox>(io.github.droidkaigi.confsched2019.settings.R.id.event_hashtag_key).setOnCheckedChangeListener { buttonView, isChecked ->
+            android.preference.PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putBoolean(EVENT_HUSHTAG, isChecked)
+                .apply()
+        }
+
+
+        view.findViewById<CheckBox>(io.github.droidkaigi.confsched2019.settings.R.id.room_hashtag_key).isChecked = settingContents.preferences [ROOM_HUSHTAG]!!
+        view.findViewById<CheckBox>(io.github.droidkaigi.confsched2019.settings.R.id.room_hashtag_key).setOnCheckedChangeListener { buttonView, isChecked ->
+            android.preference.PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putBoolean(ROOM_HUSHTAG, isChecked)
+                .apply()
+        }
+
+    }
+
+    companion object {
+        private const val SESSION_TITLE = "session_title_key"
+        private const val SESSION_URL = "session_url_key"
+        private const val EVENT_HUSHTAG = "event_hashtag_key"
+        private const val ROOM_HUSHTAG = "room_hashtag_key"
+    }
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+    }
+}
+
+@Module
+abstract class SettingsFragmentModule {
+    @Module
+    companion object {
+        @PageScope
+        @JvmStatic
+        @Provides
+        fun providesLifecycle(
+            settingsFragment: SettingsFragment
+        ): Lifecycle {
+            return settingsFragment.viewLifecycleOwner.lifecycle
+        }
     }
 }

--- a/feature/settings/src/main/java/io/github/droidkaigi/confsched2019/settings/ui/SettingsStore.kt
+++ b/feature/settings/src/main/java/io/github/droidkaigi/confsched2019/settings/ui/SettingsStore.kt
@@ -1,0 +1,22 @@
+package io.github.droidkaigi.confsched2019.settings.ui
+
+import androidx.lifecycle.LiveData
+import io.github.droidkaigi.confsched2019.action.Action
+import io.github.droidkaigi.confsched2019.dispatcher.Dispatcher
+import io.github.droidkaigi.confsched2019.ext.toLiveData
+import io.github.droidkaigi.confsched2019.model.SettingContents
+import io.github.droidkaigi.confsched2019.store.Store
+import kotlinx.coroutines.channels.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+class SettingsStore @Inject constructor(
+    dispatcher: Dispatcher
+) : Store() {
+
+    val settingsResult : LiveData<SettingContents> = dispatcher
+
+        .subscribe<Action.SettingContentsChanged>()
+        .map { SettingContents(it.contents) }
+        .toLiveData(this, null)
+}

--- a/feature/settings/src/main/res/layout/settings_fragment.xml
+++ b/feature/settings/src/main/res/layout/settings_fragment.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <CheckBox
+        android:id="@+id/session_title_key"
+        android:layout_width="335dp"
+        android:layout_height="25dp"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="100dp"
+        android:contentDescription="@string/session_title_summary"
+        android:key="@string/session_title_key"
+        android:text="@string/session_title_title"
+        android:textAppearance="@style/TextAppearance.AppCompat.Small"
+        android:textSize="18sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="MissingConstraints"
+        />
+
+    <CheckBox
+        android:id="@+id/session_url_key"
+        android:layout_width="333dp"
+        android:layout_height="29dp"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="16dp"
+        android:contentDescription="@string/session_url_summary"
+        android:key="@string/session_url_key"
+        android:text="@string/session_url_title"
+        android:textSize="18sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView4"
+        tools:ignore="MissingConstraints"
+        />
+
+    <CheckBox
+        android:id="@+id/event_hashtag_key"
+        android:layout_width="334dp"
+        android:layout_height="28dp"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="16dp"
+        android:contentDescription="@string/event_hashtag_summary"
+        android:key="@string/event_hashtag_key"
+        android:text="@string/event_hashtag_title"
+        android:textSize="18sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView2"
+        tools:ignore="MissingConstraints"
+        />
+
+    <CheckBox
+        android:id="@+id/room_hashtag_key"
+        android:layout_width="334dp"
+        android:layout_height="28dp"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="16dp"
+        android:contentDescription="@string/room_hashtag_summary"
+        android:key="@string/room_hashtag_key"
+        android:text="@string/room_hashtag_title"
+        android:textSize="18sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView3"
+        tools:ignore="MissingConstraints"
+        />
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="32dp"
+        android:layout_marginStart="16dp"
+        android:text="@string/share_setting_title"
+        android:textColor="@color/design_default_color_on_secondary"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toTopOf="@+id/session_title_key"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        />
+
+    <TextView
+        android:id="@+id/textView2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/session_url_summary"
+        app:layout_constraintStart_toStartOf="@+id/textView4"
+        app:layout_constraintTop_toBottomOf="@+id/session_url_key"
+        />
+
+    <TextView
+        android:id="@+id/textView3"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:text="@string/event_hashtag_summary"
+        app:layout_constraintStart_toStartOf="@+id/textView2"
+        app:layout_constraintTop_toBottomOf="@+id/event_hashtag_key"
+        />
+
+    <TextView
+        android:id="@+id/textView4"
+        android:layout_width="242dp"
+        android:layout_height="38dp"
+        android:layout_marginStart="59dp"
+        android:text="@string/session_title_summary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/session_title_key"
+        />
+
+    <TextView
+        android:id="@+id/textView5"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/room_hashtag_summary"
+        app:layout_constraintStart_toStartOf="@+id/textView3"
+        app:layout_constraintTop_toBottomOf="@+id/room_hashtag_key"
+        />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/settings/src/main/res/values/bools.xml
+++ b/feature/settings/src/main/res/values/bools.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="session_title_default">true</bool>
+    <bool name="session_url_default">true</bool>
+    <bool name="event_hashtag_default">true</bool>
+    <bool name="room_hashtag_default">true</bool>
+</resources>

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -1,3 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name ="share_setting_title">Sharing Settings for Tweet</string>
+    <string name ="share_setting_key">share_setting</string>
+
+    <string name ="session_title_title">Session Title</string>
+    <string name ="session_title_key">session_title</string>
+    <string name ="session_title_summary">ex.What will be changed on tests in multi-module projects</string>
+
+    <string name ="session_url_title">Session URL</string>
+    <string name ="session_url_key">session_url</string>
+    <string name ="session_url_summary">ex.https://droidkaigi.jp/2019/..</string>
+
+    <string name ="event_hashtag_title">Event Hashtag</string>
+    <string name ="event_hashtag_key">event_hashtag</string>
+    <string name ="event_hashtag_summary">ex.#droidkaigi</string>
+
+    <string name ="room_hashtag_title">Room Hashtag</string>
+    <string name ="room_hashtag_key">room_hashtag</string>
+    <string name ="room_hashtag_summary">ex.#hallA, #room1</string>
+
 </resources>

--- a/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/App.kt
+++ b/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/App.kt
@@ -18,6 +18,7 @@ import io.github.droidkaigi.confsched2019.announcement.ui.subscribeAnnouncementT
 import io.github.droidkaigi.confsched2019.di.createAppComponent
 import io.github.droidkaigi.confsched2019.ext.changedForever
 import io.github.droidkaigi.confsched2019.model.SystemProperty
+import io.github.droidkaigi.confsched2019.settings.ui.SettingsStore
 import io.github.droidkaigi.confsched2019.system.actioncreator.SystemActionCreator
 import io.github.droidkaigi.confsched2019.system.store.SystemStore
 import timber.log.LogcatTree

--- a/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/MainActivity.kt
+++ b/frontend/android/src/main/java/io/github/droidkaigi/confsched2019/ui/MainActivity.kt
@@ -54,6 +54,8 @@ import io.github.droidkaigi.confsched2019.session.ui.SpeakerFragment
 import io.github.droidkaigi.confsched2019.session.ui.SpeakerFragmentModule
 import io.github.droidkaigi.confsched2019.session.ui.TabularFormSessionPagesFragment
 import io.github.droidkaigi.confsched2019.session.ui.TabularFromSessionPagesFragmentModule
+import io.github.droidkaigi.confsched2019.settings.ui.SettingsFragment
+import io.github.droidkaigi.confsched2019.settings.ui.SettingsFragmentModule
 import io.github.droidkaigi.confsched2019.sponsor.ui.SponsorFragment
 import io.github.droidkaigi.confsched2019.sponsor.ui.SponsorFragmentModule
 import io.github.droidkaigi.confsched2019.staff.ui.StaffSearchFragment
@@ -126,8 +128,10 @@ class MainActivity : DaggerAppCompatActivity() {
     }
 
     private fun setupNavigation() {
-        val topLevelDestinationIds = setOf(R.id.main, R.id.about, R.id.announce, R.id.setting,
-            R.id.floormap, R.id.sponsor, R.id.contributor)
+        val topLevelDestinationIds = setOf(
+            R.id.main, R.id.about, R.id.announce, R.id.setting,
+            R.id.floormap, R.id.sponsor, R.id.contributor
+        )
         val appBarConfiguration = AppBarConfiguration(
             topLevelDestinationIds,
             binding.drawerLayout
@@ -332,6 +336,10 @@ abstract class MainActivityModule {
         modules = [ContributorFragmentModule::class, ContributorAssistedInjectModule::class]
     )
     abstract fun contrbutorContributorFragment(): ContributorFragment
+
+    @PageScope
+    @ContributesAndroidInjector(modules = [SettingsFragmentModule::class])
+    abstract fun contributeSettingsFragment(): SettingsFragment
 
     @Module
     companion object {

--- a/frontend/android/src/main/res/menu/menu_nav_drawer.xml
+++ b/frontend/android/src/main/res/menu/menu_nav_drawer.xml
@@ -46,18 +46,17 @@
             android:icon="@drawable/ic_contributor_outline_24dp"
             android:title="@string/contributor"/>
 
-        <!-- TODO If we can create item, we should uncomment it -->
-        <!--<item-->
-        <!--android:id="@id/setting"-->
-        <!--android:icon="@drawable/ic_settings_outline_black_24dp"-->
-        <!--android:title="@string/setting_label"-->
-        <!--/>-->
+        <item
+            android:id="@id/setting"
+            android:icon="@drawable/ic_settings_outline_black_24dp"
+            android:title="@string/setting_label"
+            />
 
-        <!-- Below items are just placeholder to avoid hidden under nav footer -->
         <item
             android:enabled="false"
             android:title=""
             />
+
         <item
             android:enabled="false"
             android:title=""

--- a/model/src/commonMain/kotlin/SettingContents.kt
+++ b/model/src/commonMain/kotlin/SettingContents.kt
@@ -1,0 +1,12 @@
+package io.github.droidkaigi.confsched2019.model
+
+data class SettingContents(
+    val preferences: MutableMap<String, Boolean> = mutableMapOf(sessionTit to false, sessionUrl to false, eventHashtag to false, roomHashtag to false)
+) {
+    companion object {
+        private const val sessionTit = "session_title_key"
+        private const val sessionUrl = "session_url_key"
+        private const val eventHashtag = "event_hashtag_key"
+        private const val roomHashtag = "room_hashtag_key"
+    }
+}


### PR DESCRIPTION
## Issue
- #573 
## Overview (Required)
-Added share settings on the settings page. Because PreferenceFragmentCompat disabled Dagger, I used checkboxs and ConstraintLayout without PreferenceScreen.
I'm very sorry for the late submission.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
